### PR TITLE
Fix plugin URL in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use { 'Saecki/crates.nvim', requires = { 'nvim-lua/plenary.nvim' } }
 For lazy loading:
 ```lua
 use {
-    '~/Projects/crates.nvim',
+    'Saecki/crates.nvim',
     event = { "BufRead Cargo.toml" },
     requires = { { 'nvim-lua/plenary.nvim' } },
     config = function()


### PR DESCRIPTION
I think most people want to use the Github URL instead of your local folder.