### PR TITLE
Use unpack() instead of table.unpack()

### DIFF
--- a/lua/crates/popup.lua
+++ b/lua/crates/popup.lua
@@ -587,7 +587,7 @@ function Popup.toggle_feature(index)
          table.insert(c, cf)
       end
    end
-   Popup.feat_ctx.crate = Crate.new(vim.tbl_extend("force", crate, table.unpack(c)))
+   Popup.feat_ctx.crate = Crate.new(vim.tbl_extend("force", crate, unpack(c)))
    crate = Popup.feat_ctx.crate
 
 

--- a/teal/crates/popup.tl
+++ b/teal/crates/popup.tl
@@ -587,7 +587,7 @@ function Popup.toggle_feature(index: integer)
             table.insert(c, cf)
         end
     end
-    Popup.feat_ctx.crate = Crate.new(vim.tbl_extend("force", crate as table, table.unpack(c) as table) as Crate)
+    Popup.feat_ctx.crate = Crate.new(vim.tbl_extend("force", crate as table, unpack(c) as table) as Crate)
     crate = Popup.feat_ctx.crate
 
     -- update buffer

--- a/types/types.d.tl
+++ b/types/types.d.tl
@@ -1,1 +1,3 @@
 require("vim")
+
+global unpack: function<T>({T}, number, number): T...


### PR DESCRIPTION
table.unpack() is not work in neovim LuaJIT 2.1.0-beta3

`toggle_feature` doesn't work properly because of table.unpack()

![image](https://user-images.githubusercontent.com/72651387/142816307-a4cf16ec-3cda-4c20-acde-64f642baf40c.png)
