### PR TITLE
docs: update readme and vimdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,14 @@ require('cmp').setup {
 ```
 
 Or add it lazily.
-```viml
-autocmd FileType toml lua require('cmp').setup.buffer { sources = { { name = 'crates' } } }
+```lua
+vim.api.nvim_create_autocmd("BufRead", {
+    group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
+    pattern = "Cargo.toml",
+    callback = function() 
+        cmp.setup.buffer({ sources = { { name = "crates" } } }) 
+    end,
+})
 ```
 
 ### [coq.nvim](https://github.com/ms-jpq/coq_nvim) source
@@ -398,26 +404,29 @@ require('crates').hide_popup()
 ```
 
 ### Key mappings
-Some examples of key mappings.
-```vim
-nnoremap <silent> <leader>ct :lua require('crates').toggle()<cr>
-nnoremap <silent> <leader>cr :lua require('crates').reload()<cr>
+Some examples of key mappings. 
+```lua
+local crates = require('crates')
+local opts = { noremap = true, silent = true }
 
-nnoremap <silent> <leader>cv :lua require('crates').show_versions_popup()<cr>
-nnoremap <silent> <leader>cf :lua require('crates').show_features_popup()<cr>
-nnoremap <silent> <leader>cd :lua require('crates').show_dependencies_popup()<cr>
+vim.keymap.set('n', '<leader>ct', crates.toggle, opts)
+vim.keymap.set('n', '<leader>cr', crates.reload, opts)
 
-nnoremap <silent> <leader>cu :lua require('crates').update_crate()<cr>
-vnoremap <silent> <leader>cu :lua require('crates').update_crates()<cr>
-nnoremap <silent> <leader>ca :lua require('crates').update_all_crates()<cr>
-nnoremap <silent> <leader>cU :lua require('crates').upgrade_crate()<cr>
-vnoremap <silent> <leader>cU :lua require('crates').upgrade_crates()<cr>
-nnoremap <silent> <leader>cA :lua require('crates').upgrade_all_crates()<cr>
+vim.keymap.set('n', '<leader>cv', crates.show_versions_popup, opts)
+vim.keymap.set('n', '<leader>cf', crates.show_features_popup, opts)
+vim.keymap.set('n', '<leader>cd', crates.show_dependencies_popup, opts)
 
-nnoremap <silent> <leader>cH :lua require('crates').open_homepage()<cr>
-nnoremap <silent> <leader>cR :lua require('crates').open_repository()<cr>
-nnoremap <silent> <leader>cD :lua require('crates').open_documentation()<cr>
-nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
+vim.keymap.set('n', '<leader>cu', crates.update_crate, opts)
+vim.keymap.set('v', '<leader>cu', crates.update_crates, opts)
+vim.keymap.set('n', '<leader>ca', crates.update_all_crates, opts)
+vim.keymap.set('n', '<leader>cU', crates.upgrade_crate, opts)
+vim.keymap.set('v', '<leader>cU', crates.upgrade_crates, opts)
+vim.keymap.set('n', '<leader>cA', crates.upgrade_all_crates, opts)
+
+vim.keymap.set('n', '<leader>cH', crates.open_homepage, opts)
+vim.keymap.set('n', '<leader>cR', crates.open_repository, opts)
+vim.keymap.set('n', '<leader>cD', crates.open_documentation, opts)
+vim.keymap.set('n', '<leader>cC', crates.open_crates_io, opts)
 ```
 
 ### Show appropriate documentation in `Cargo.toml`
@@ -439,7 +448,6 @@ endfunction
 
 How you might integrate `show_popup` into your `init.lua`.
 ```lua
-vim.api.nvim_set_keymap('n', 'K', ':lua show_documentation()', { noremap = true, silent = true })
 function show_documentation()
     local filetype = vim.bo.filetype
     if vim.tbl_contains({ 'vim','help' }, filetype) then
@@ -452,6 +460,8 @@ function show_documentation()
         vim.lsp.buf.hover()
     end
 end
+
+vim.keymap.set('n', 'K', show_documentation, { noremap = true, silent = true })
 ```
 
 ## Related projects

--- a/README.md
+++ b/README.md
@@ -112,14 +112,8 @@ require('cmp').setup {
 ```
 
 Or add it lazily.
-```lua
-vim.api.nvim_create_autocmd("BufRead", {
-    group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
-    pattern = "Cargo.toml",
-    callback = function() 
-        cmp.setup.buffer({ sources = { { name = "crates" } } }) 
-    end,
-})
+```viml
+autocmd FileType toml lua require('cmp').setup.buffer { sources = { { name = 'crates' } } }
 ```
 
 ### [coq.nvim](https://github.com/ms-jpq/coq_nvim) source
@@ -404,29 +398,26 @@ require('crates').hide_popup()
 ```
 
 ### Key mappings
-Some examples of key mappings. 
-```lua
-local crates = require('crates')
-local opts = { noremap = true, silent = true }
+Some examples of key mappings.
+```vim
+nnoremap <silent> <leader>ct :lua require('crates').toggle()<cr>
+nnoremap <silent> <leader>cr :lua require('crates').reload()<cr>
 
-vim.keymap.set('n', '<leader>ct', crates.toggle, opts)
-vim.keymap.set('n', '<leader>cr', crates.reload, opts)
+nnoremap <silent> <leader>cv :lua require('crates').show_versions_popup()<cr>
+nnoremap <silent> <leader>cf :lua require('crates').show_features_popup()<cr>
+nnoremap <silent> <leader>cd :lua require('crates').show_dependencies_popup()<cr>
 
-vim.keymap.set('n', '<leader>cv', crates.show_versions_popup, opts)
-vim.keymap.set('n', '<leader>cf', crates.show_features_popup, opts)
-vim.keymap.set('n', '<leader>cd', crates.show_dependencies_popup, opts)
+nnoremap <silent> <leader>cu :lua require('crates').update_crate()<cr>
+vnoremap <silent> <leader>cu :lua require('crates').update_crates()<cr>
+nnoremap <silent> <leader>ca :lua require('crates').update_all_crates()<cr>
+nnoremap <silent> <leader>cU :lua require('crates').upgrade_crate()<cr>
+vnoremap <silent> <leader>cU :lua require('crates').upgrade_crates()<cr>
+nnoremap <silent> <leader>cA :lua require('crates').upgrade_all_crates()<cr>
 
-vim.keymap.set('n', '<leader>cu', crates.update_crate, opts)
-vim.keymap.set('v', '<leader>cu', crates.update_crates, opts)
-vim.keymap.set('n', '<leader>ca', crates.update_all_crates, opts)
-vim.keymap.set('n', '<leader>cU', crates.upgrade_crate, opts)
-vim.keymap.set('v', '<leader>cU', crates.upgrade_crates, opts)
-vim.keymap.set('n', '<leader>cA', crates.upgrade_all_crates, opts)
-
-vim.keymap.set('n', '<leader>cH', crates.open_homepage, opts)
-vim.keymap.set('n', '<leader>cR', crates.open_repository, opts)
-vim.keymap.set('n', '<leader>cD', crates.open_documentation, opts)
-vim.keymap.set('n', '<leader>cC', crates.open_crates_io, opts)
+nnoremap <silent> <leader>cH :lua require('crates').open_homepage()<cr>
+nnoremap <silent> <leader>cR :lua require('crates').open_repository()<cr>
+nnoremap <silent> <leader>cD :lua require('crates').open_documentation()<cr>
+nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
 ```
 
 ### Show appropriate documentation in `Cargo.toml`
@@ -448,6 +439,7 @@ endfunction
 
 How you might integrate `show_popup` into your `init.lua`.
 ```lua
+vim.api.nvim_set_keymap('n', 'K', ':lua show_documentation()', { noremap = true, silent = true })
 function show_documentation()
     local filetype = vim.bo.filetype
     if vim.tbl_contains({ 'vim','help' }, filetype) then
@@ -460,8 +452,6 @@ function show_documentation()
         vim.lsp.buf.hover()
     end
 end
-
-vim.keymap.set('n', 'K', show_documentation, { noremap = true, silent = true })
 ```
 
 ## Related projects

--- a/scripts/README.md.in
+++ b/scripts/README.md.in
@@ -237,7 +237,7 @@ nnoremap <silent> <leader>cD :lua require('crates').open_documentation()<cr>
 nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
 ```
 
-You can use vim.keymap.set to map lua function to keys directly.
+You can use `vim.keymap.set` to map lua function to keys directly.
 ```lua
 local crates = require('crates')
 local opts = { noremap = true, silent = true }

--- a/scripts/README.md.in
+++ b/scripts/README.md.in
@@ -112,8 +112,14 @@ require('cmp').setup {
 ```
 
 Or add it lazily.
-```viml
-autocmd FileType toml lua require('cmp').setup.buffer { sources = { { name = 'crates' } } }
+```lua
+vim.api.nvim_create_autocmd("BufRead", {
+    group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
+    pattern = "Cargo.toml",
+    callback = function()
+        cmp.setup.buffer({ sources = { { name = "crates" } } })
+    end,
+})
 ```
 
 ### [coq.nvim](https://github.com/ms-jpq/coq_nvim) source
@@ -231,6 +237,31 @@ nnoremap <silent> <leader>cD :lua require('crates').open_documentation()<cr>
 nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
 ```
 
+You can use vim.keymap.set to map lua function to keys directly.
+```lua
+local crates = require('crates')
+local opts = { noremap = true, silent = true }
+
+vim.keymap.set('n', '<leader>ct', crates.toggle, opts)
+vim.keymap.set('n', '<leader>cr', crates.reload, opts)
+
+vim.keymap.set('n', '<leader>cv', crates.show_versions_popup, opts)
+vim.keymap.set('n', '<leader>cf', crates.show_features_popup, opts)
+vim.keymap.set('n', '<leader>cd', crates.show_dependencies_popup, opts)
+
+vim.keymap.set('n', '<leader>cu', crates.update_crate, opts)
+vim.keymap.set('v', '<leader>cu', crates.update_crates, opts)
+vim.keymap.set('n', '<leader>ca', crates.update_all_crates, opts)
+vim.keymap.set('n', '<leader>cU', crates.upgrade_crate, opts)
+vim.keymap.set('v', '<leader>cU', crates.upgrade_crates, opts)
+vim.keymap.set('n', '<leader>cA', crates.upgrade_all_crates, opts)
+
+vim.keymap.set('n', '<leader>cH', crates.open_homepage, opts)
+vim.keymap.set('n', '<leader>cR', crates.open_repository, opts)
+vim.keymap.set('n', '<leader>cD', crates.open_documentation, opts)
+vim.keymap.set('n', '<leader>cC', crates.open_crates_io, opts)
+```
+
 ### Show appropriate documentation in `Cargo.toml`
 How you might integrate `show_popup` into your `init.vim`.
 ```vim
@@ -250,7 +281,6 @@ endfunction
 
 How you might integrate `show_popup` into your `init.lua`.
 ```lua
-vim.api.nvim_set_keymap('n', 'K', ':lua show_documentation()', { noremap = true, silent = true })
 function show_documentation()
     local filetype = vim.bo.filetype
     if vim.tbl_contains({ 'vim','help' }, filetype) then
@@ -263,6 +293,8 @@ function show_documentation()
         vim.lsp.buf.hover()
     end
 end
+
+vim.keymap.set('n', 'K', show_documentation, { noremap = true, silent = true })
 ```
 
 ## Related projects

--- a/scripts/README.md.in
+++ b/scripts/README.md.in
@@ -281,7 +281,7 @@ endfunction
 
 How you might integrate `show_popup` into your `init.lua`.
 ```lua
-function show_documentation()
+local function show_documentation()
     local filetype = vim.bo.filetype
     if vim.tbl_contains({ 'vim','help' }, filetype) then
         vim.cmd('h '..vim.fn.expand('<cword>'))

--- a/scripts/crates.txt.in
+++ b/scripts/crates.txt.in
@@ -102,6 +102,31 @@ For more information about the lua function see |crates-functions|.
     nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
 <
 
+You can use vim.keymap.set to map lua function to keys directly.
+>
+    local crates = require('crates')
+    local opts = { noremap = true, silent = true }
+
+    vim.keymap.set('n', '<leader>ct', crates.toggle, opts)
+    vim.keymap.set('n', '<leader>cr', crates.reload, opts)
+
+    vim.keymap.set('n', '<leader>cv', crates.show_versions_popup, opts)
+    vim.keymap.set('n', '<leader>cf', crates.show_features_popup, opts)
+    vim.keymap.set('n', '<leader>cd', crates.show_dependencies_popup, opts)
+
+    vim.keymap.set('n', '<leader>cu', crates.update_crate, opts)
+    vim.keymap.set('v', '<leader>cu', crates.update_crates, opts)
+    vim.keymap.set('n', '<leader>ca', crates.update_all_crates, opts)
+    vim.keymap.set('n', '<leader>cU', crates.upgrade_crate, opts)
+    vim.keymap.set('v', '<leader>cU', crates.upgrade_crates, opts)
+    vim.keymap.set('n', '<leader>cA', crates.upgrade_all_crates, opts)
+
+    vim.keymap.set('n', '<leader>cH', crates.open_homepage, opts)
+    vim.keymap.set('n', '<leader>cR', crates.open_repository, opts)
+    vim.keymap.set('n', '<leader>cD', crates.open_documentation, opts)
+    vim.keymap.set('n', '<leader>cC', crates.open_crates_io, opts)
+<
+
 To integrate the crates popup in an idiomatic way into your configuration, you
 might want to use one of the following snippets for contextual documentation.
 
@@ -123,7 +148,6 @@ How you might integrate `show_popup` into your `init.vim`.
 
 How you might integrate `show_popup` into your `init.lua`.
 >
-    vim.api.nvim_set_keymap('n', 'K', ':lua show_documentation()', { noremap = true, silent = true })
     function show_documentation()
         local filetype = vim.bo.filetype
         if vim.tbl_contains({ 'vim','help' }, filetype) then
@@ -136,6 +160,8 @@ How you might integrate `show_popup` into your `init.lua`.
             vim.lsp.buf.hover()
         end
     end
+
+    vim.keymap.set('n', 'K', show_documentation, { noremap = true, silent = true })
 <
 
 ==============================================================================

--- a/scripts/crates.txt.in
+++ b/scripts/crates.txt.in
@@ -102,7 +102,7 @@ For more information about the lua function see |crates-functions|.
     nnoremap <silent> <leader>cC :lua require('crates').open_crates_io()<cr>
 <
 
-You can use vim.keymap.set to map lua function to keys directly.
+You can use |vim.keymap.set()| to map lua function to keys directly.
 >
     local crates = require('crates')
     local opts = { noremap = true, silent = true }

--- a/scripts/crates.txt.in
+++ b/scripts/crates.txt.in
@@ -148,7 +148,7 @@ How you might integrate `show_popup` into your `init.vim`.
 
 How you might integrate `show_popup` into your `init.lua`.
 >
-    function show_documentation()
+    local function show_documentation()
         local filetype = vim.bo.filetype
         if vim.tbl_contains({ 'vim','help' }, filetype) then
             vim.cmd('h '..vim.fn.expand('<cword>'))


### PR DESCRIPTION
- Change `autocmd` command for lazy loading cmp source to a lua function equivalent 
- Change `nvim_set_keymap` to the newer `vim.keymap.set` which can map keys to lua functions directly
- Add `vim.keymap.set` equivalent for `noremap` commands