### PR TITLE
fix: don't show duplicate crate entry error for renamed crate

### DIFF
--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -193,7 +193,7 @@ function Crate:is_def_enabled()
 end
 
 function Crate:cache_key()
-   return string.format("%s:%s:%s", self.section.target or "", self.section.kind, self.name)
+   return string.format("%s:%s:%s", self.section.target or "", self.section.kind, self.rename or self.name)
 end
 
 

--- a/teal/crates/toml.tl
+++ b/teal/crates/toml.tl
@@ -193,7 +193,7 @@ function Crate:is_def_enabled(): boolean
 end
 
 function Crate:cache_key(): string
-    return string.format("%s:%s:%s", self.section.target or "", self.section.kind, self.name)
+    return string.format("%s:%s:%s", self.section.target or "", self.section.kind, self.rename or self.name)
 end
 
 


### PR DESCRIPTION
Fixes #33