### PR TITLE
feat: support workspace dependencies

### DIFF
--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -209,6 +209,14 @@ function M.parse_section(text)
       }
 
       local target = prefix
+
+      local workspace = prefix:match("^workspace%s*%.$")
+      if workspace then
+
+         target = ""
+         prefix = ""
+      end
+
       local dev_target = prefix:match("^(.*)dev%-$")
       if dev_target then
          target = vim.trim(dev_target)

--- a/teal/crates/toml.tl
+++ b/teal/crates/toml.tl
@@ -209,6 +209,14 @@ function M.parse_section(text: string): Section
         }
 
         local target = prefix
+
+        local workspace = prefix:match("^workspace%s*%.$")
+        if workspace then
+        -- the workspace table only allows a regular dependencies sub-table
+            target = ""
+            prefix = ""
+        end
+
         local dev_target = prefix:match("^(.*)dev%-$")
         if dev_target then
             target = vim.trim(dev_target)


### PR DESCRIPTION
[Workspace inheritance](https://github.com/rust-lang/cargo/issues/8415) was recently [stabilized](https://github.com/rust-lang/cargo/pull/10859) and will be included in the `1.64` release on [Sep 22 2022](https://forge.rust-lang.org/#current-release-versions).

This PR simply treats the `[workspace.dependencies]` table as a default table, since it previously were treated as an invalid dependency section. Per the [RFC](https://rust-lang.github.io/rfcs/2906-cargo-workspace-deduplicate.html#updates-to-workspace), only regular `dependencies` are supported in the `[workspace]` table.