### PR TITLE
Add `popup_available` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ require('crates').open_documentation()
 -- Open the `crates.io` page of the crate on the current line.
 require('crates').open_crates_io()
 
+-- Returns a boolean indicating whether there is information to show in a popup.
+require('crates').popup_available()
 -- Show/hide popup with crate details, all versions, all features or details about one feature.
 -- If `popup.autofocus` is disabled calling this again will focus the popup.
 require('crates').show_popup()
@@ -488,7 +490,7 @@ local function show_documentation()
         vim.cmd('h '..vim.fn.expand('<cword>'))
     elseif vim.tbl_contains({ 'man' }, filetype) then
         vim.cmd('Man '..vim.fn.expand('<cword>'))
-    elseif vim.fn.expand('%:t') == 'Cargo.toml' then
+    elseif vim.fn.expand('%:t') == 'Cargo.toml' and require('crates').popup_available() then
         require('crates').show_popup()
     else
         vim.lsp.buf.hover()

--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -384,6 +384,10 @@ open_crates_io()                                     *crates.open_crates_io()*
     Open the `crates.io` page of the crate on the current line.
 
 
+popup_available()                                   *crates.popup_available()*
+    Returns a boolean indicating whether there is information to show in a popup.
+
+
 show_popup()                                             *crates.show_popup()*
     Show/hide popup with crate details, all versions, all features or details about one feature.
     If |crates-config-popup-autofocus| is disabled calling this again will focus the popup.

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -61,6 +61,8 @@ local M = {}
 
 
 
+
+
 local actions = require("crates.actions")
 local config = require("crates.config")
 local Config = config.Config
@@ -157,6 +159,7 @@ M.open_repository = actions.open_repository
 M.open_documentation = actions.open_documentation
 M.open_crates_io = actions.open_crates_io
 
+M.popup_available = popup.available
 M.show_popup = popup.show
 M.show_crate_popup = popup.show_crate
 M.show_versions_popup = popup.show_versions

--- a/lua/crates/popup/dependencies.lua
+++ b/lua/crates/popup/dependencies.lua
@@ -153,7 +153,7 @@ function M.open_deps(ctx, crate_name, version, opts)
    local title = string.format(state.cfg.popup.text.title, crate_name .. " " .. version.num)
    local deps_width = 0
    local deps_text_index = {}
-
+   local HlTextDepList = {}
 
 
 

--- a/lua/crates/popup/dependencies.lua
+++ b/lua/crates/popup/dependencies.lua
@@ -153,7 +153,7 @@ function M.open_deps(ctx, crate_name, version, opts)
    local title = string.format(state.cfg.popup.text.title, crate_name .. " " .. version.num)
    local deps_width = 0
    local deps_text_index = {}
-   local HlTextDepList = {}
+
 
 
 

--- a/lua/crates/popup/init.lua
+++ b/lua/crates/popup/init.lua
@@ -105,6 +105,10 @@ local function line_crate_info()
    return info
 end
 
+function M.available()
+   return line_crate_info() and true
+end
+
 function M.show()
    if popup.win and vim.api.nvim_win_is_valid(popup.win) then
       popup.focus()

--- a/scripts/README.md.in
+++ b/scripts/README.md.in
@@ -293,7 +293,7 @@ local function show_documentation()
         vim.cmd('h '..vim.fn.expand('<cword>'))
     elseif vim.tbl_contains({ 'man' }, filetype) then
         vim.cmd('Man '..vim.fn.expand('<cword>'))
-    elseif vim.fn.expand('%:t') == 'Cargo.toml' then
+    elseif vim.fn.expand('%:t') == 'Cargo.toml' and require('crates').popup_available() then
         require('crates').show_popup()
     else
         vim.lsp.buf.hover()

--- a/teal/crates/init.tl
+++ b/teal/crates/init.tl
@@ -43,6 +43,8 @@ local record M
     -- Open the `crates.io` page of the crate on the current line.
     open_crates_io: function()
 
+    -- Returns a boolean indicating whether there is information to show in a popup.
+    popup_available: function()
     -- Show/hide popup with crate details, all versions, all features or details about one feature.
     -- If `c#popup.autofocus` is disabled calling this again will focus the popup.
     show_popup: function()
@@ -157,6 +159,7 @@ M.open_repository = actions.open_repository
 M.open_documentation = actions.open_documentation
 M.open_crates_io = actions.open_crates_io
 
+M.popup_available = popup.available
 M.show_popup = popup.show
 M.show_crate_popup = popup.show_crate
 M.show_versions_popup = popup.show_versions

--- a/teal/crates/popup/init.tl
+++ b/teal/crates/popup/init.tl
@@ -105,6 +105,10 @@ local function line_crate_info(): LineCrateInfo
     return info
 end
 
+function M.available(): boolean
+    return line_crate_info() and true
+end
+
 function M.show()
     if popup.win and vim.api.nvim_win_is_valid(popup.win) then
         popup.focus()


### PR DESCRIPTION
This function simply allows the user to ask `crates.nvim` whether it has a popup to show at the current position. I also updated the [example `show_documentation`](https://github.com/Saecki/crates.nvim#show-appropriate-documentation-in-cargotoml) function to include this check to allow the LSP to show hover information in other areas of a `Cargo.toml` file.