### PR TITLE
fix: add diagnostic for invalid crate name casing

### DIFF
--- a/lua/crates/actions.lua
+++ b/lua/crates/actions.lua
@@ -123,6 +123,12 @@ function M.open_crates_io()
    end
 end
 
+local function rename_crate_action(buf, crate, name)
+   return function()
+      edit.rename_crate(buf, crate, name)
+   end
+end
+
 local function remove_diagnostic_range_action(buf, d)
    return function()
       vim.api.nvim_buf_set_text(buf, d.lnum, d.col, d.end_lnum, d.end_col, {})
@@ -177,6 +183,8 @@ function M.get_actions()
          actions["remove_duplicate_crate"] = remove_diagnostic_range_action(buf, d)
       elseif d.kind == "crate_dup_orig" then
          actions["remove_original_crate"] = remove_diagnostic_range_action(buf, d)
+      elseif d.kind == "crate_name_case" then
+         actions["rename_crate"] = rename_crate_action(buf, d.data["crate"], d.data["crate_name"])
 
       elseif crate and d.kind == "feat_dup" then
          actions["remove_duplicate_feature"] = remove_feature_action(buf, crate, d.data["feat"])

--- a/lua/crates/config.lua
+++ b/lua/crates/config.lua
@@ -216,6 +216,7 @@ local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {
 
 
 
+
 local Config = M.Config
 local SchemaElement = M.SchemaElement
 local SchemaType = M.SchemaType
@@ -509,6 +510,11 @@ entry(schema_diagnostic, "crate_novers", {
 entry(schema_diagnostic, "crate_error_fetching", {
    type = "string",
    default = "Error fetching crate",
+   hidden = true,
+})
+entry(schema_diagnostic, "crate_name_case", {
+   type = "string",
+   default = "Incorrect crate name casing",
    hidden = true,
 })
 entry(schema_diagnostic, "vers_upgrade", {

--- a/lua/crates/core.lua
+++ b/lua/crates/core.lua
@@ -61,8 +61,10 @@ M.reload_crate = async.wrap(function(crate_name)
 
       for k, c in pairs(cache.crates) do
          if c.name == crate_name and vim.api.nvim_buf_is_loaded(b) then
-            local info, diagnostics = diagnostic.process_crate_versions(c, versions)
+            local info, diagnostics = diagnostic.process_api_crate(c, crate)
             cache.info[k] = info
+            vim.list_extend(cache.diagnostics, diagnostics)
+
             ui.display_crate_info(b, info, diagnostics)
 
             local version = info.vers_match or info.vers_upgrade
@@ -98,11 +100,11 @@ function M.update(buf, reload)
       local versions = crate and crate.versions
 
       if not reload and crate then
-         local info, v_diagnostics = diagnostic.process_crate_versions(c, versions)
+         local info, c_diagnostics = diagnostic.process_api_crate(c, crate)
          cache.info[k] = info
-         vim.list_extend(cache.diagnostics, v_diagnostics)
+         vim.list_extend(cache.diagnostics, c_diagnostics)
 
-         ui.display_crate_info(buf, info, v_diagnostics)
+         ui.display_crate_info(buf, info, c_diagnostics)
 
          local version = info.vers_match or info.vers_upgrade
          if version then

--- a/lua/crates/edit.lua
+++ b/lua/crates/edit.lua
@@ -10,6 +10,10 @@ local Range = types.Range
 local SemVer = types.SemVer
 local Requirement = types.Requirement
 
+function M.rename_crate(buf, crate, name)
+   vim.api.nvim_buf_set_text(buf, crate.lines.s, crate.name_col.s, crate.lines.s, crate.name_col.e, { name })
+end
+
 local function insert_version(buf, crate, text)
    if not crate.vers then
       if crate.syntax == "table" then

--- a/lua/crates/types.lua
+++ b/lua/crates/types.lua
@@ -139,6 +139,7 @@ local M = {CrateInfo = {}, Diagnostic = {}, Crate = {}, Version = {}, Features =
 
 
 
+
 local Diagnostic = M.Diagnostic
 local Feature = M.Feature
 local Features = M.Features

--- a/teal/crates/actions.tl
+++ b/teal/crates/actions.tl
@@ -123,6 +123,12 @@ function M.open_crates_io()
     end
 end
 
+local function rename_crate_action(buf: integer, crate: toml.Crate, name: string): function
+    return function()
+        edit.rename_crate(buf, crate, name)
+    end
+end
+
 local function remove_diagnostic_range_action(buf: integer, d: Diagnostic): function
     return function()
         vim.api.nvim_buf_set_text(buf, d.lnum, d.col, d.end_lnum, d.end_col, {})
@@ -177,6 +183,8 @@ function M.get_actions(): {string:function}
             actions["remove_duplicate_crate"] = remove_diagnostic_range_action(buf, d)
         elseif d.kind == "crate_dup_orig" then
             actions["remove_original_crate"] = remove_diagnostic_range_action(buf, d)
+        elseif d.kind == "crate_name_case" then
+            actions["rename_crate"] = rename_crate_action(buf, d.data["crate"] as toml.Crate, d.data["crate_name"] as string)
 
         elseif crate and d.kind == "feat_dup" then
             actions["remove_duplicate_feature"] = remove_feature_action(buf, crate, d.data["feat"] as toml.Feature)

--- a/teal/crates/config.tl
+++ b/teal/crates/config.tl
@@ -50,6 +50,7 @@ local record M
             crate_dup_orig: string
             crate_novers: string
             crate_error_fetching: string
+            crate_name_case: string
             vers_upgrade: string
             vers_pre: string
             vers_yanked: string
@@ -509,6 +510,11 @@ entry(schema_diagnostic, "crate_novers", {
 entry(schema_diagnostic, "crate_error_fetching", {
     type = "string",
     default = "Error fetching crate",
+    hidden = true,
+})
+entry(schema_diagnostic, "crate_name_case", {
+    type = "string",
+    default = "Incorrect crate name casing",
     hidden = true,
 })
 entry(schema_diagnostic, "vers_upgrade", {

--- a/teal/crates/core.tl
+++ b/teal/crates/core.tl
@@ -61,8 +61,10 @@ M.reload_crate = async.wrap(function(crate_name: string)
         -- update crate in all dependency sections
         for k,c in pairs(cache.crates) do
             if c.name == crate_name and vim.api.nvim_buf_is_loaded(b) then
-                local info, diagnostics = diagnostic.process_crate_versions(c, versions)
+                local info, diagnostics = diagnostic.process_api_crate(c, crate)
                 cache.info[k] = info
+                vim.list_extend(cache.diagnostics, diagnostics)
+
                 ui.display_crate_info(b, info, diagnostics)
 
                 local version = info.vers_match or info.vers_upgrade
@@ -98,11 +100,11 @@ function M.update(buf: integer|nil, reload: boolean)
         local versions = crate and crate.versions
 
         if not reload and crate then
-            local info, v_diagnostics = diagnostic.process_crate_versions(c, versions)
+            local info, c_diagnostics = diagnostic.process_api_crate(c, crate)
             cache.info[k] = info
-            vim.list_extend(cache.diagnostics, v_diagnostics)
+            vim.list_extend(cache.diagnostics, c_diagnostics)
 
-            ui.display_crate_info(buf, info, v_diagnostics)
+            ui.display_crate_info(buf, info, c_diagnostics)
 
             local version: Version = info.vers_match or info.vers_upgrade
             if version then

--- a/teal/crates/diagnostic.tl
+++ b/teal/crates/diagnostic.tl
@@ -17,6 +17,7 @@ local semver = require("crates.semver")
 local state = require("crates.state")
 local toml = require("crates.toml")
 local types = require("crates.types")
+local Crate = types.Crate
 local CrateInfo = types.CrateInfo
 local Dependency = types.Dependency
 local Diagnostic = types.Diagnostic
@@ -24,7 +25,13 @@ local DiagnosticKind = types.DiagnosticKind
 local Version = types.Version
 local util = require("crates.util")
 
-local function section_diagnostic(section: toml.Section, kind: DiagnosticKind, severity: integer, scope: SectionScope|nil, data: {string:any}): Diagnostic
+local function section_diagnostic(
+    section: toml.Section,
+    kind: DiagnosticKind,
+    severity: integer,
+    scope: SectionScope|nil,
+    data: {string:any}
+): Diagnostic
     local d = Diagnostic.new {
         lnum = section.lines.s,
         end_lnum = section.lines.e,
@@ -46,7 +53,8 @@ local function crate_diagnostic(
     crate: toml.Crate,
     kind: DiagnosticKind,
     severity: integer,
-    scope: CrateScope|nil
+    scope: CrateScope|nil,
+    data: {string:any}
 ): Diagnostic
     local d = Diagnostic.new {
         lnum = crate.lines.s,
@@ -55,6 +63,7 @@ local function crate_diagnostic(
         end_col = 0,
         severity = severity,
         kind = kind,
+        data = data,
     }
 
     if not scope then
@@ -210,8 +219,9 @@ function M.process_crates(sections: {toml.Section}, crates: {toml.Crate}): {stri
     return cache, diagnostics
 end
 
-function M.process_crate_versions(crate: toml.Crate, versions: {Version}): CrateInfo, {Diagnostic}
+function M.process_api_crate(crate: toml.Crate, api_crate: Crate): CrateInfo, {Diagnostic}
     local avoid_pre = state.cfg.avoid_prerelease and not crate:vers_is_pre()
+    local versions = api_crate and api_crate.versions
     local newest, newest_pre, newest_yanked = util.get_newest(versions, avoid_pre, nil)
     newest = newest or newest_pre or newest_yanked
 
@@ -227,6 +237,18 @@ function M.process_crate_versions(crate: toml.Crate, versions: {Version}): Crate
         info.dep_kind = "git"
     else
         info.dep_kind = "registry"
+    end
+    
+    if api_crate then
+        if api_crate.name ~= crate.name then
+            table.insert(diagnostics, crate_diagnostic(
+                crate,
+                "crate_name_case",
+                vim.diagnostic.severity.ERROR,
+                nil,
+                { crate = crate, crate_name = api_crate.name }
+            ))
+        end
     end
 
     if info.dep_kind == "registry" then

--- a/teal/crates/edit.tl
+++ b/teal/crates/edit.tl
@@ -10,6 +10,10 @@ local Range = types.Range
 local SemVer = types.SemVer
 local Requirement = types.Requirement
 
+function M.rename_crate(buf: integer, crate: toml.Crate, name: string)
+    vim.api.nvim_buf_set_text(buf, crate.lines.s, crate.name_col.s, crate.lines.s, crate.name_col.e, { name })
+end
+
 local function insert_version(buf: integer, crate: toml.Crate, text: string): Range
     if not crate.vers then
         if crate.syntax == "table" then

--- a/teal/crates/toml.tl
+++ b/teal/crates/toml.tl
@@ -6,6 +6,7 @@ local record M
         target: string|nil
         kind: Kind
         name: string|nil
+        name_col: Range
         lines: Range
 
         enum Kind
@@ -18,6 +19,7 @@ local record M
     record Crate
         name: string
         rename: string|nil
+        name_col: Range
         lines: Range
         syntax: Syntax
         vers: Vers
@@ -108,15 +110,15 @@ local Range = types.Range
 local Requirement = types.Requirement
 
 local function inline_table_bool_pattern(name: string): string
-    return "^%s*([^%s]+)%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,]*)()%s*()[,]?.*[}]?%s*$"
+    return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,]*)()%s*()[,]?.*[}]?%s*$"
 end
 
 local function inline_table_str_pattern(name: string): string
-    return [[^%s*([^%s]+)%s*=%s*{.-[,]?()%s*]] .. name .. [[%s*=%s*(["'])()([^"']*)()(["']?)%s*()[,]?.*[}]?%s*$]]
+    return [[^%s()*([^%s]+)()%s*=%s*{.-[,]?()%s*]] .. name .. [[%s*=%s*(["'])()([^"']*)()(["']?)%s*()[,]?.*[}]?%s*$]]
 end
 
 local function inline_table_str_array_pattern(name: string): string
-    return "^%s*([^%s]+)%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*%[()([^%]]*)()[%]]?%s*()[,]?.*[}]?%s*$"
+    return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*%[()([^%]]*)()[%]]?%s*()[,]?.*[}]?%s*$"
 end
 
 local INLINE_TABLE_VERS_PATTERN = inline_table_str_pattern("version")
@@ -204,8 +206,8 @@ function Crate:cache_key(): string
 end
 
 
-function M.parse_section(text: string): Section
-    local prefix, suffix = text:match("^(.*)dependencies(.*)$")
+function M.parse_section(text: string, start: integer): Section
+    local prefix, suffix_s, suffix = text:match("^(.*)dependencies()(.*)$")
     if prefix and suffix then
         prefix = vim.trim(prefix)
         suffix = vim.trim(suffix)
@@ -244,9 +246,11 @@ function M.parse_section(text: string): Section
         end
 
         if suffix then
-            local n = suffix:match("^%.(.+)$")
+            local n_s, n, n_e = suffix:match("^%.%s*()(.+)()%s*$")
             if n then
                 section.name = vim.trim(n)
+                local offset = start + suffix_s as integer - 1
+                section.name_col = Range.new(n_s as integer - 1 + offset, n_e as integer - 1 + offset)
                 suffix = ""
             end
         end
@@ -331,9 +335,10 @@ function M.parse_crate_table_def(line: string): Crate
 end
 
 local function parse_inline_table_str(crate: {string:any}, entry: string, line: string, pattern: string)
-    local name, decl_s, quote_s, str_s, text, str_e, quote_e, decl_e = line:match(pattern)
+    local name_s, name, name_e, decl_s, quote_s, str_s, text, str_e, quote_e, decl_e = line:match(pattern)
     if name then
         crate.name = name
+        crate.name_col = Range.new(name_s as integer - 1, name_e as integer - 1)
         crate.syntax = "inline_table"
         crate[entry] = {
             text = text,
@@ -347,10 +352,11 @@ end
 function M.parse_crate(line: string): Crate
     -- plain version
     do
-        local name, quote_s, str_s, text, str_e, quote_e = line:match([[^%s*([^%s]+)%s*=%s*(["'])()([^"']*)()(["']?)%s*$]])
+        local name_s, name, name_e, quote_s, str_s, text, str_e, quote_e = line:match([[^%s*()([^%s]+)()%s*=%s*(["'])()([^"']*)()(["']?)%s*$]])
         if name then
             return {
                 name = name,
+                name_col = Range.new(name_s as integer - 1, name_e as integer - 1),
                 syntax = "plain",
                 vers = {
                     text = text,
@@ -370,9 +376,10 @@ function M.parse_crate(line: string): Crate
     parse_inline_table_str(crate, "git", line, INLINE_TABLE_GIT_PATTERN)
 
     do
-        local name, decl_s, array_s, text, array_e, decl_e = line:match(INLINE_TABLE_FEAT_PATTERN)
+        local name_s, name, name_e, decl_s, array_s, text, array_e, decl_e = line:match(INLINE_TABLE_FEAT_PATTERN)
         if name then
             crate.name = name
+            crate.name_col = Range.new(name_s as integer - 1, name_e as integer - 1)
             crate.syntax = "inline_table"
             crate.feat = {
                 text = text,
@@ -383,9 +390,10 @@ function M.parse_crate(line: string): Crate
     end
 
     do
-        local name, decl_s, bool_s, text, bool_e, decl_e = line:match(INLINE_TABLE_DEF_PATTERN)
+        local name_s, name, name_e, decl_s, bool_s, text, bool_e, decl_e = line:match(INLINE_TABLE_DEF_PATTERN)
         if name then
             crate.name = name
+            crate.name_col = Range.new(name_s as integer - 1, name_e as integer - 1)
             crate.syntax = "inline_table"
             crate.def = {
                 text = text,
@@ -397,10 +405,11 @@ function M.parse_crate(line: string): Crate
 
     -- renames the crate so has to stay last
     do
-        local name, decl_s, quote_s, str_s, text, str_e, quote_e, decl_e = line:match(INLINE_TABLE_PKG_PATTERN)
+        local name_s, name, name_e, decl_s, quote_s, str_s, text, str_e, quote_e, decl_e = line:match(INLINE_TABLE_PKG_PATTERN)
         if name then
             crate.name = text
             crate.rename = name
+            crate.name_col = Range.new(name_s as integer - 1, name_e as integer - 1)
             crate.syntax = "inline_table"
             crate.pkg = {
                 text = text,
@@ -435,7 +444,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
     for i,l in ipairs(lines) do
         l = M.trim_comments(l)
 
-        local section_text = l:match("^%s*%[(.+)%]%s*$")
+        local section_start, section_text = l:match("^%s*%[()(.+)%]%s*$")
 
         if section_text then
             if dep_section then
@@ -449,7 +458,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
                 end
             end
 
-            local section = M.parse_section(section_text)
+            local section = M.parse_section(section_text, section_start as integer - 1)
 
             if section then
                 section.lines = Range.new(i - 1, nil)
@@ -464,6 +473,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_vers = M.parse_crate_table_vers(l)
             if crate_vers then
                 crate_vers.name = dep_section.name
+                crate_vers.name_col = dep_section.name_col
                 crate_vers.vers.line = i - 1
                 crate_vers.section = dep_section
                 dep_section_crate = vim.tbl_extend("keep", dep_section_crate or {}, crate_vers) as Crate
@@ -472,6 +482,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_path = M.parse_crate_table_path(l)
             if crate_path then
                 crate_path.name = dep_section.name
+                crate_path.name_col = dep_section.name_col
                 crate_path.path.line = i - 1
                 crate_path.section = dep_section
                 dep_section_crate = vim.tbl_extend("keep", dep_section_crate or {}, crate_path) as Crate
@@ -480,6 +491,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_git = M.parse_crate_table_git(l)
             if crate_git then
                 crate_git.name = dep_section.name
+                crate_git.name_col = dep_section.name_col
                 crate_git.git.line = i - 1
                 crate_git.section = dep_section
                 dep_section_crate = vim.tbl_extend("keep", dep_section_crate or {}, crate_git) as Crate
@@ -488,6 +500,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_feat = M.parse_crate_table_feat(l)
             if crate_feat then
                 crate_feat.name = dep_section.name
+                crate_feat.name_col = dep_section.name_col
                 crate_feat.feat.line = i - 1
                 crate_feat.section = dep_section
                 dep_section_crate = vim.tbl_extend("keep", dep_section_crate or {}, crate_feat) as Crate
@@ -496,6 +509,7 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_def = M.parse_crate_table_def(l)
             if crate_def then
                 crate_def.name = dep_section.name
+                crate_def.name_col = dep_section.name_col
                 crate_def.def.line = i - 1
                 crate_def.section = dep_section
                 dep_section_crate = vim.tbl_extend("keep", dep_section_crate or {}, crate_def) as Crate
@@ -505,8 +519,9 @@ function M.parse_crates(buf: integer): {Section}, {Crate}
             local crate_pkg = M.parse_crate_table_pkg(l)
             if crate_pkg then
                 local crate = dep_section_crate or {}
-                crate.rename = dep_section.name
                 crate.name = crate_pkg.pkg.text
+                crate.rename = dep_section.name
+                crate.name_col = dep_section.name_col
 
                 crate_pkg.pkg.line = i - 1
                 crate_pkg.section = dep_section

--- a/teal/crates/types.tl
+++ b/teal/crates/types.tl
@@ -42,6 +42,7 @@ local record M
         "crate_dup"
         "crate_novers"
         "crate_error_fetching"
+        "crate_name_case"
         "vers_nomatch"
         "vers_yanked"
         "def_invalid"


### PR DESCRIPTION
closes #44 by adding a diagnostic for mismatched crate name casing. Also adds an action to rename the crate to the correct one.