### PR TITLE
fix(toml): inline tables without extra spaces at the end

### DIFF
--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -110,7 +110,7 @@ local Range = types.Range
 local Requirement = types.Requirement
 
 local function inline_table_bool_pattern(name)
-   return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,]*)()%s*()[,]?.*[}]?%s*$"
+   return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,}]*)()%s*()[,]?.*[}]?%s*$"
 end
 
 local function inline_table_str_pattern(name)

--- a/teal/crates/toml.tl
+++ b/teal/crates/toml.tl
@@ -110,7 +110,7 @@ local Range = types.Range
 local Requirement = types.Requirement
 
 local function inline_table_bool_pattern(name: string): string
-    return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,]*)()%s*()[,]?.*[}]?%s*$"
+    return "^%s*()([^%s]+)()%s*=%s*{.-[,]?()%s*" .. name .. "%s*=%s*()([^%s,}]*)()%s*()[,]?.*[}]?%s*$"
 end
 
 local function inline_table_str_pattern(name: string): string


### PR DESCRIPTION
minimal example of the bug:
```toml
[dependencies]
serde = { version = "*", default-features = false}
```
without this, `Invalid boolean value` is shown