### PR TITLE
fix: popup showing netrw a dir named "crates" exists

### DIFF
--- a/lua/crates/popup/common.lua
+++ b/lua/crates/popup/common.lua
@@ -118,8 +118,11 @@ local function set_buf_content(buf, title, text)
 
    set_buf_body(text)
 
-   vim.api.nvim_buf_set_name(buf, "crates")
    vim.api.nvim_buf_set_option(buf, "modifiable", false)
+   vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+   vim.api.nvim_buf_set_option(buf, "swapfile", false)
+   vim.api.nvim_buf_set_option(buf, "filetype", "crates.nvim")
+   vim.api.nvim_buf_set_name(buf, "crates:popup")
 end
 
 function M.update_win(width, height, title, text, opts)

--- a/teal/crates/popup/common.tl
+++ b/teal/crates/popup/common.tl
@@ -118,8 +118,11 @@ local function set_buf_content(buf: integer, title: string, text: {{HighlightTex
 
     set_buf_body(text)
 
-    vim.api.nvim_buf_set_name(buf, "crates")
     vim.api.nvim_buf_set_option(buf, "modifiable", false)
+    vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+    vim.api.nvim_buf_set_option(buf, "swapfile", false)
+    vim.api.nvim_buf_set_option(buf, "filetype", "crates.nvim")
+    vim.api.nvim_buf_set_name(buf, "crates:popup")
 end
 
 function M.update_win(width: integer, height: integer, title: string, text: {{HighlightText}}, opts: WinOpts)


### PR DESCRIPTION
Fixes #53 by choosing a more uncommon name for the popup buffer.