### PR TITLE
feat: add `flatpak-xdg-open` as open URL provider

### DIFF
--- a/lua/crates/health.lua
+++ b/lua/crates/health.lua
@@ -27,7 +27,9 @@ function M.check()
       health_error("curl not found")
    end
 
-   if util.binary_installed("xdg-open") then
+   if util.binary_installed("flatpak-xdg-open") then
+      health_ok("flatpak-xdg-open installed")
+   elseif util.binary_installed("xdg-open") then
       health_ok("xdg-open installed")
    elseif util.binary_installed("open") then
       health_ok("open installed")

--- a/lua/crates/util.lua
+++ b/lua/crates/util.lua
@@ -171,7 +171,15 @@ function M.crates_io_url(name)
 end
 
 function M.open_url(url)
-   if M.binary_installed("xdg-open") then
+
+
+
+
+
+
+   if M.binary_installed("flatpak-xdg-open") then
+      vim.cmd("silent !flatpak-xdg-open " .. url)
+   elseif M.binary_installed("xdg-open") then
       vim.cmd("silent !xdg-open " .. url)
    elseif M.binary_installed("open") then
       vim.cmd("silent !open " .. url)

--- a/teal/crates/health.tl
+++ b/teal/crates/health.tl
@@ -27,7 +27,9 @@ function M.check()
         health_error("curl not found")
     end
 
-    if util.binary_installed("xdg-open") then
+    if util.binary_installed("flatpak-xdg-open") then
+		health_ok("flatpak-xdg-open installed")
+    elseif util.binary_installed("xdg-open") then
         health_ok("xdg-open installed")
     elseif util.binary_installed("open") then
         health_ok("open installed")

--- a/teal/crates/util.tl
+++ b/teal/crates/util.tl
@@ -171,7 +171,15 @@ function M.crates_io_url(name: string): string
 end
 
 function M.open_url(url: string)
-    if M.binary_installed("xdg-open") then
+	-- We check for `flatpak-xdg-open` first because there is a chance that
+	-- `xdg-open` will still be available in the users path within a {distro,tool}box.
+	-- E.g. 'xdg-open' is installed at `~/.local/bin/xdg-open` which will still be
+	-- available in the sandbox.
+	-- In which case using `xdg-open' will fail silently, as it will not be able
+	-- to escape the sandbox.
+    if M.binary_installed("flatpak-xdg-open") then
+		vim.cmd("silent !flatpak-xdg-open " .. url)
+    elseif M.binary_installed("xdg-open") then
         vim.cmd("silent !xdg-open " .. url)
     elseif M.binary_installed("open") then
         vim.cmd("silent !open " .. url)


### PR DESCRIPTION
When running `nvim` inside a [distrobox](https://github.com/89luca89/distrobox) or a [toolbx](https://containertoolbx.org/) `xdg-open` is not available. Or if it is, it will fail silently as it cannot escape the container sandbox. `flatpak-xdg-open` can be used to remedy this. This PR checks to see if `flatpak-xdg-open` is available, and if so uses it as a `open_url()` handler.