### PR TITLE
fix: trigger initial update when lazy loading

### DIFF
--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -80,6 +80,10 @@ function M.setup(cfg)
 
    local group = vim.api.nvim_create_augroup("Crates", {})
    if state.cfg.autoload then
+      if vim.fn.expand("%:t") == "Cargo.toml" then
+         M.update()
+      end
+
       vim.api.nvim_create_autocmd("BufRead", {
          group = group,
          pattern = "Cargo.toml",

--- a/teal/crates/init.tl
+++ b/teal/crates/init.tl
@@ -80,6 +80,10 @@ function M.setup(cfg: Config)
 
     local group = vim.api.nvim_create_augroup("Crates", {})
     if state.cfg.autoload then
+        if vim.fn.expand("%:t") == "Cargo.toml" then
+          M.update()
+        end
+
         vim.api.nvim_create_autocmd("BufRead", {
             group = group,
             pattern = "Cargo.toml",


### PR DESCRIPTION
Fix the scenario when lazy loading with `BufRead Cargo.toml` event, `M.update()` was not called immediately.