### PR TITLE
fix: limit number of parallel requests using a queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ require('crates').setup {
     thousands_separator = ".",
     notification_title = "Crates",
     curl_args = { "-sL", "--retry", "1" },
+    max_parallel_requests = 80,
     open_programs = { "xdg-open", "open" },
     disable_invalid_feature_diagnostic = false,
     text = {

--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -85,6 +85,7 @@ For more information about individual config options see |crates-config|.
         thousands_separator = ".",
         notification_title = "Crates",
         curl_args = { "-sL", "--retry", "1" },
+        max_parallel_requests = 80,
         open_programs = { "xdg-open", "open" },
         disable_invalid_feature_diagnostic = false,
         text = {
@@ -512,6 +513,12 @@ curl_args                                            *crates-config-curl_args*
     Type: `table`, Default: `{ "-sL", "--retry", "1" }`
 
     A list of arguments passed to curl when fetching metadata from crates.io.
+
+
+max_parallel_requests                    *crates-config-max_parallel_requests*
+    Type: `number`, Default: `80`
+
+    Maximum number of parallel requests.
 
 
 open_programs                                    *crates-config-open_programs*

--- a/lua/crates/config.lua
+++ b/lua/crates/config.lua
@@ -222,6 +222,7 @@ local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {
 
 
 
+
 local Config = M.Config
 local SchemaElement = M.SchemaElement
 local SchemaType = M.SchemaType
@@ -326,6 +327,13 @@ entry(M.schema, "curl_args", {
    default = { "-sL", "--retry", "1" },
    description = [[
         A list of arguments passed to curl when fetching metadata from crates.io.
+    ]],
+})
+entry(M.schema, "max_parallel_requests", {
+   type = "number",
+   default = 80,
+   description = [[
+        Maximum number of parallel requests.
     ]],
 })
 entry(M.schema, "open_programs", {

--- a/teal/crates/api.tl
+++ b/teal/crates/api.tl
@@ -1,20 +1,34 @@
 local record M
+    run_queued_jobs: function()
+
     crate_jobs: {string:CrateJob}
     deps_jobs: {string:DepsJob}
+    queued_jobs: {QueuedJob}
+    num_requests: integer
 
     record CrateJob
         job: Job
         callbacks: {function(Crate, boolean)}
     end
 
-    record VersJob
-        job: Job
-        callbacks: {function({Version}, boolean)}
-    end
-
     record DepsJob
         job: Job
         callbacks: {function({Dependency}, boolean)}
+    end
+
+    record QueuedJob
+        kind: JobKind
+        name: string
+        
+        crate_callbacks: {function(Crate|nil, boolean)}
+        
+        version: string
+        deps_callbacks: {function({Dependency}|nil, boolean)}
+    end
+
+    enum JobKind
+        "crate"
+        "deps"
     end
 end
 
@@ -35,6 +49,8 @@ local JSON_DECODE_OPTS: vim.json.DecodeOpts = { luanil = { object = true, array 
 
 M.crate_jobs = {}
 M.deps_jobs = {}
+M.queued_jobs = {}
+M.num_requests = 0
 
 
 local function parse_json(json_str: string): table
@@ -58,6 +74,36 @@ local function request_job(url: string, on_exit: function(j: Job, code: integer,
         args = { unpack(state.cfg.curl_args), "-A", USERAGENT, url },
         on_exit = vim.schedule_wrap(on_exit) as function(Job, integer, integer),
     }
+end
+
+local function enqueue_crate_job(name: string, callbacks: {function(Crate|nil, boolean)})
+    for _,j in ipairs(M.queued_jobs) do
+        if j.kind == "crate" and j.name == name then
+            vim.list_extend(j.crate_callbacks, callbacks)
+            return
+        end
+    end
+        
+    table.insert(M.queued_jobs, {
+        kind = "crate",
+        name = name,
+        crate_callbacks = callbacks,
+    })
+end
+
+local function enqueue_deps_job(name: string, version: string, callbacks: {function({Dependency}|nil, boolean)})
+    for _,j in ipairs(M.queued_jobs) do
+        if j.kind == "deps" and j.name == name and j.version == version then
+            vim.list_extend(j.deps_callbacks, callbacks)
+        end
+    end
+    
+    table.insert(M.queued_jobs, {
+        kind = "deps",
+        name = name,
+        version = version,
+        deps_callbacks = callbacks,
+    })
 end
 
 
@@ -151,12 +197,18 @@ function M.parse_crate(json_str: string): Crate|nil
     return crate
 end
 
-local function fetch_crate(name: string, callback: function(Crate|nil, boolean))
-    if M.crate_jobs[name] then
+local function fetch_crate(name: string, callbacks: {function(Crate|nil, boolean)})
+    local exisiting = M.crate_jobs[name]
+    if exisiting then
+        vim.list_extend(exisiting.callbacks, callbacks)
+        return
+    end
+    
+    if M.num_requests >= state.cfg.max_parallel_requests then
+        enqueue_crate_job(name, callbacks)
         return
     end
 
-    local callbacks = { callback }
     local url = string.format("%s/crates/%s", ENDPOINT, name)
 
     local function on_exit(j: Job, code: integer, signal: integer)
@@ -176,9 +228,13 @@ local function fetch_crate(name: string, callback: function(Crate|nil, boolean))
         end
 
         M.crate_jobs[name] = nil
+        M.num_requests = M.num_requests - 1
+
+        M.run_queued_jobs()
     end
 
     local job = request_job(url, on_exit)
+    M.num_requests = M.num_requests + 1
     M.crate_jobs[name] = {
         job = job,
         callbacks = callbacks,
@@ -188,7 +244,7 @@ end
 
 function M.fetch_crate(name: string): Crate, boolean
     return coroutine.yield(function(resolve: function(Crate, boolean))
-        fetch_crate(name, resolve)
+        fetch_crate(name, {resolve})
     end) as (Crate, boolean)
 end
 
@@ -218,13 +274,19 @@ function M.parse_deps(json_str: string): {Dependency}|nil
     return dependencies
 end
 
-local function fetch_deps(name: string, version: string, callback: function({Dependency}, boolean))
+local function fetch_deps(name: string, version: string, callbacks: {function({Dependency}, boolean)})
     local jobname = name .. ":" .. version
-    if M.deps_jobs[jobname] then
+    local exisiting = M.deps_jobs[jobname]
+    if exisiting then
+        vim.list_extend(exisiting.callbacks, callbacks)
         return
     end
 
-    local callbacks = { callback }
+    if M.num_requests >= state.cfg.max_parallel_requests then
+        enqueue_deps_job(name, version, callbacks)
+        return
+    end
+
     local url = string.format("%s/crates/%s/%s/dependencies", ENDPOINT, name, version)
 
     local function on_exit(j: Job, code: integer, signal: integer)
@@ -243,10 +305,12 @@ local function fetch_deps(name: string, version: string, callback: function({Dep
             c(deps, cancelled)
         end
 
+        M.num_requests = M.num_requests - 1
         M.deps_jobs[jobname] = nil
     end
 
     local job = request_job(url, on_exit)
+    M.num_requests = M.num_requests + 1
     M.deps_jobs[jobname] = {
         job = job,
         callbacks = callbacks,
@@ -256,9 +320,10 @@ end
 
 function M.fetch_deps(name: string, version: string): {Dependency}, boolean
     return coroutine.yield(function(resolve: function({Dependency}, boolean))
-        fetch_deps(name, version, resolve)
+        fetch_deps(name, version, {resolve})
     end) as ({Dependency}, boolean)
 end
+
 
 function M.is_fetching_crate(name: string): boolean
     return M.crate_jobs[name] ~= nil
@@ -292,6 +357,19 @@ function M.await_deps(name: string, version: string): {Dependency}, boolean
     return coroutine.yield(function(resolve: function({Dependency}, boolean))
         add_deps_callback(name, version, resolve)
     end) as ({Dependency}, boolean)
+end
+
+function M.run_queued_jobs()
+    if #M.queued_jobs == 0 then
+        return
+    end
+
+    local job = table.remove(M.queued_jobs, 1)
+    if job.kind == "crate" then
+        fetch_crate(job.name, job.crate_callbacks)
+    elseif job.kind == "deps" then
+        fetch_deps(job.name, job.version, job.deps_callbacks)
+    end
 end
 
 function M.cancel_jobs()

--- a/teal/crates/config.tl
+++ b/teal/crates/config.tl
@@ -14,6 +14,7 @@ local record M
         notification_title: string
         curl_args: {string}
         open_programs: {string}
+        max_parallel_requests: integer
         disable_invalid_feature_diagnostic: boolean
         text: TextConfig
         highlight: HighlightConfig
@@ -326,6 +327,13 @@ entry(M.schema, "curl_args", {
     default = { "-sL", "--retry", "1" },
     description = [[
         A list of arguments passed to curl when fetching metadata from crates.io.
+    ]],
+})
+entry(M.schema, "max_parallel_requests", {
+    type = "number",
+    default = 80,
+    description = [[
+        Maximum number of parallel requests.
     ]],
 })
 entry(M.schema, "open_programs", {


### PR DESCRIPTION
Fixes #62 by introducing the `max_parallel_requests` config option (default `80`).