### PR TITLE
feat(config): add 'on_attach'

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ require('crates').setup {
         enabled = false,
         name = "Crates",
     },
+    on_attach = function(bufnr) end,
 }
 ```
 

--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -216,6 +216,7 @@ For more information about individual config options see |crates-config|.
             enabled = false,
             name = "Crates",
         },
+        on_attach = function(bufnr) end,
     }
 <
 
@@ -1294,6 +1295,13 @@ null_ls.name                                      *crates-config-null_ls-name*
     Type: `string`, Default: `"Crates"`
 
     The |null-ls.nvim| name.
+
+
+on_attach                                            *crates-config-on_attach*
+    Type: `function`, Default: `function(bufnr) end`
+
+  Callback to run when Cargo.toml is opened.
+  Ignored if `autoload` is disabled.
 
 
 

--- a/lua/crates/config.lua
+++ b/lua/crates/config.lua
@@ -223,6 +223,8 @@ local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {
 
 
 
+
+
 local Config = M.Config
 local SchemaElement = M.SchemaElement
 local SchemaType = M.SchemaType
@@ -1368,6 +1370,16 @@ entry(schema_null_ls, "name", {
    default = "Crates",
    description = [[
         The |null-ls.nvim| name.
+    ]],
+})
+
+entry(M.schema, "on_attach", {
+   type = "function",
+   default = function(_bufnr) end,
+   default_text = "function(bufnr) end",
+   description = [[
+      Callback to run when Cargo.toml is opened.
+      Ignored if `autoload` is disabled.
     ]],
 })
 

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -73,6 +73,10 @@ local state = require("crates.state")
 local ui = require("crates.ui")
 local util = require("crates.util")
 
+
+
+
+
 function M.setup(cfg)
    state.cfg = config.build(cfg)
 
@@ -82,13 +86,15 @@ function M.setup(cfg)
    if state.cfg.autoload then
       if vim.fn.expand("%:t") == "Cargo.toml" then
          M.update()
+         state.cfg.on_attach(vim.api.nvim_get_current_buf())
       end
 
       vim.api.nvim_create_autocmd("BufRead", {
          group = group,
          pattern = "Cargo.toml",
-         callback = function()
+         callback = function(info)
             M.update()
+            state.cfg.on_attach(info.buf)
          end,
       })
    end

--- a/scripts/gen_doc.lua
+++ b/scripts/gen_doc.lua
@@ -240,7 +240,7 @@ local function gen_def_config(lines, indent, path, schema)
                 gen_def_config(lines, indent, p, s.fields)
                 insert_indent("},")
             else
-                local d = inspect(s.default)
+                local d = s.default_text or inspect(s.default)
                 insert_indent(string.format("%s = %s,", name, d))
             end
         end

--- a/teal/crates/config.tl
+++ b/teal/crates/config.tl
@@ -22,6 +22,7 @@ local record M
         popup: PopupConfig
         src: SrcConfig
         null_ls: NullLsConfig
+        on_attach: function(bufnr: integer): nil
 
         record TextConfig
             loading: string
@@ -204,6 +205,7 @@ local record M
         "string"
         "number"
         "boolean"
+        "function"
     end
 
     record SchemaElement
@@ -1368,6 +1370,16 @@ entry(schema_null_ls, "name", {
     default = "Crates",
     description = [[
         The |null-ls.nvim| name.
+    ]],
+})
+
+entry(M.schema, "on_attach", {
+    type = "function",
+    default = function(_bufnr) end,
+    default_text = "function(bufnr) end",
+    description = [[
+      Callback to run when Cargo.toml is opened.
+      Ignored if `autoload` is disabled.
     ]],
 })
 

--- a/teal/crates/init.tl
+++ b/teal/crates/init.tl
@@ -73,6 +73,10 @@ local state = require("crates.state")
 local ui = require("crates.ui")
 local util = require("crates.util")
 
+local record AutocmdInfo
+  buf: integer
+end
+
 function M.setup(cfg: Config)
     state.cfg = config.build(cfg)
 
@@ -82,13 +86,15 @@ function M.setup(cfg: Config)
     if state.cfg.autoload then
         if vim.fn.expand("%:t") == "Cargo.toml" then
           M.update()
+          state.cfg.on_attach(vim.api.nvim_get_current_buf())
         end
 
         vim.api.nvim_create_autocmd("BufRead", {
             group = group,
             pattern = "Cargo.toml",
-            callback = function()
+            callback = function(info: AutocmdInfo)
                 M.update()
+                state.cfg.on_attach(info.buf)
             end,
         })
     end


### PR DESCRIPTION
Useful for adding keymaps when `Cargo.toml` is opened.

```lua
require("crates").setup({
  on_attach = function(bufnr)
    require("config.utils").set_keymaps("n", {
      {
        "<Leader>ac",
        vim.lsp.buf.code_action,
        "[lsp] code action",
        mode = { "n", "v" },
      },
      {
        "K",
        function()
          if crates.popup_available() then
            crates.show_popup()
          else
            vim.lsp.buf.hover()
          end
        end,
        "[lsp] hover",
      },
    }, { buffer = bufnr })
  end,
  null_ls = {
    enabled = true,
    name = "crates.nvim",
  },
})
```