### PR TITLE
fix: avoid checkhealth deprecation warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,5 @@ make doc
 There are currently only a few tests.
 Execute them by running this command:
 ```
-make test`
+make test
 ```

--- a/lua/crates/health.lua
+++ b/lua/crates/health.lua
@@ -3,10 +3,11 @@ local M = {}
 local state = require("crates.state")
 local util = require("crates.util")
 
-local health_start = vim.fn["health#report_start"]
-local health_ok = vim.fn["health#report_ok"]
-local health_warn = vim.fn["health#report_warn"]
-local health_error = vim.fn["health#report_error"]
+local health = vim.health or require("health")
+local health_start = health.start or health.report_start
+local health_ok = health.ok or health.report_ok
+local health_warn = health.warn or health.report_warn
+local health_error = health.error or health.report_error
 
 function M.check()
    health_start("Checking required plugins")

--- a/teal/crates/health.tl
+++ b/teal/crates/health.tl
@@ -3,10 +3,11 @@ local record M end
 local state = require("crates.state")
 local util = require("crates.util")
 
-local health_start = vim.fn["health#report_start"]
-local health_ok = vim.fn["health#report_ok"]
-local health_warn = vim.fn["health#report_warn"]
-local health_error = vim.fn["health#report_error"]
+local health = vim.health or require "health"
+local health_start = health.start or health.report_start
+local health_ok = health.ok or health.report_ok
+local health_warn = health.warn or health.report_warn
+local health_error = health.error or health.report_error
 
 function M.check()
     health_start("Checking required plugins")

--- a/teal/crates/health.tl
+++ b/teal/crates/health.tl
@@ -3,7 +3,7 @@ local record M end
 local state = require("crates.state")
 local util = require("crates.util")
 
-local health = vim.health or require "health"
+local health = vim.health or require("health")
 local health_start = health.start or health.report_start
 local health_ok = health.ok or health.report_ok
 local health_warn = health.warn or health.report_warn

--- a/types/health.d.tl
+++ b/types/health.d.tl
@@ -1,0 +1,14 @@
+local record health
+    start: function(any)
+    info: function(any)
+    ok: function(any)
+    warn: function(any, ...: any)
+    error: function(any, ...: any)
+    report_start: function(any)
+    report_info: function(any)
+    report_ok: function(any)
+    report_warn: function(any, ...: any)
+    report_error: function(any, ...: any)
+end
+
+return health

--- a/types/vim.d.tl
+++ b/types/vim.d.tl
@@ -2134,4 +2134,17 @@ global record vim
       end
       select: function(any, SelectOpts, function(any, integer))
    end
+
+   record health
+      start: function(any)
+      info: function(any)
+      ok: function(any)
+      warn: function(any, ...: any)
+      error: function(any, ...: any)
+      report_start: function(any)
+      report_info: function(any)
+      report_ok: function(any)
+      report_warn: function(any, ...: any)
+      report_error: function(any, ...: any)
+   end
 end


### PR DESCRIPTION
closes #70

health api was changed in https://github.com/neovim/neovim/pull/22927

tested on both Nvim nightly and v0.9.1

never worked with teal before so hope it's not too bad. not sure what I did with the types are good.