### PR TITLE
fix: don't show possibly misleading info or diagnostics for local depencencies

### DIFF
--- a/lua/crates/core.lua
+++ b/lua/crates/core.lua
@@ -96,11 +96,17 @@ function M.update(buf, reload)
    ui.clear(buf)
    ui.display_diagnostics(buf, diagnostics)
    for k, c in pairs(crate_cache) do
-      local crate = state.api_cache[c:package()]
-      local versions = crate and crate.versions
 
-      if not reload and crate then
-         local info, c_diagnostics = diagnostic.process_api_crate(c, crate)
+
+      if c.dep_kind ~= "registry" then
+         return
+      end
+
+      local api_crate = state.api_cache[c:package()]
+      local versions = api_crate and api_crate.versions
+
+      if not reload and api_crate then
+         local info, c_diagnostics = diagnostic.process_api_crate(c, api_crate)
          cache.info[k] = info
          vim.list_extend(cache.diagnostics, c_diagnostics)
 

--- a/lua/crates/diagnostic.lua
+++ b/lua/crates/diagnostic.lua
@@ -231,29 +231,19 @@ function M.process_api_crate(crate, api_crate)
    }
    local diagnostics = {}
 
-   if crate.workspace then
-      info.dep_kind = "workspace"
-   elseif crate.path then
-      info.dep_kind = "path"
-   elseif crate.git then
-      info.dep_kind = "git"
-   else
-      info.dep_kind = "registry"
-   end
+   if crate.dep_kind == "registry" then
+      if api_crate then
+         if api_crate.name ~= crate:package() then
+            table.insert(diagnostics, crate_diagnostic(
+            crate,
+            "crate_name_case",
+            vim.diagnostic.severity.ERROR,
+            nil,
+            { crate = crate, crate_name = api_crate.name }))
 
-   if api_crate then
-      if api_crate.name ~= crate:package() then
-         table.insert(diagnostics, crate_diagnostic(
-         crate,
-         "crate_name_case",
-         vim.diagnostic.severity.ERROR,
-         nil,
-         { crate = crate, crate_name = api_crate.name }))
-
+         end
       end
-   end
 
-   if info.dep_kind == "registry" then
       if newest then
          if semver.matches_requirements(newest.parsed, crate:vers_reqs()) then
 

--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -149,6 +149,14 @@ local M = {Section = {}, Crate = {Vers = {}, Registry = {}, Path = {}, Git = {},
 
 
 
+
+
+
+
+
+
+
+
 local Section = M.Section
 local Crate = M.Crate
 local Feature = M.Feature
@@ -195,6 +203,16 @@ function Crate.new(obj)
    end
    if obj.opt then
       obj.opt.enabled = obj.opt.text ~= "false"
+   end
+
+   if obj.workspace then
+      obj.dep_kind = "workspace"
+   elseif obj.path then
+      obj.dep_kind = "path"
+   elseif obj.git then
+      obj.dep_kind = "git"
+   else
+      obj.dep_kind = "registry"
    end
 
    return setmetatable(obj, { __index = Crate })

--- a/lua/crates/types.lua
+++ b/lua/crates/types.lua
@@ -133,14 +133,6 @@ local M = {CrateInfo = {}, Diagnostic = {}, Crate = {}, Version = {}, Features =
 
 
 
-
-
-
-
-
-
-
-
 local Diagnostic = M.Diagnostic
 local Feature = M.Feature
 local Features = M.Features

--- a/lua/crates/ui.lua
+++ b/lua/crates/ui.lua
@@ -67,11 +67,7 @@ function M.display_crate_info(buf, info, diagnostics)
       })
    end
 
-   if info.dep_kind == "path" then
-
-   elseif info.dep_kind == "git" then
-
-   elseif info.dep_kind == "registry" and not (info.vers_match or info.vers_upgrade) then
+   if not (info.vers_match or info.vers_upgrade) then
       table.insert(virt_text, {
          state.cfg.text.error,
          state.cfg.highlight.error,

--- a/teal/crates/core.tl
+++ b/teal/crates/core.tl
@@ -96,11 +96,17 @@ function M.update(buf: integer|nil, reload: boolean)
     ui.clear(buf)
     ui.display_diagnostics(buf, diagnostics)
     for k,c in pairs(crate_cache) do
-        local crate = state.api_cache[c:package()]
-        local versions = crate and crate.versions
+        -- Don't try to fetch info from crates.io if it's a local or git crate
+        -- TODO: Once there is workspace support, resolve the crate
+        if c.dep_kind ~= "registry" then
+            return
+        end
 
-        if not reload and crate then
-            local info, c_diagnostics = diagnostic.process_api_crate(c, crate)
+        local api_crate = state.api_cache[c:package()]
+        local versions = api_crate and api_crate.versions
+
+        if not reload and api_crate then
+            local info, c_diagnostics = diagnostic.process_api_crate(c, api_crate)
             cache.info[k] = info
             vim.list_extend(cache.diagnostics, c_diagnostics)
 

--- a/teal/crates/diagnostic.tl
+++ b/teal/crates/diagnostic.tl
@@ -231,29 +231,19 @@ function M.process_api_crate(crate: toml.Crate, api_crate: Crate): CrateInfo, {D
     }
     local diagnostics = {}
 
-    if crate.workspace then
-        info.dep_kind = "workspace"
-    elseif crate.path then
-        info.dep_kind = "path"
-    elseif crate.git then
-        info.dep_kind = "git"
-    else
-        info.dep_kind = "registry"
-    end
-
-    if api_crate then
-        if api_crate.name ~= crate:package() then
-            table.insert(diagnostics, crate_diagnostic(
-                crate,
-                "crate_name_case",
-                vim.diagnostic.severity.ERROR,
-                nil,
-                { crate = crate, crate_name = api_crate.name }
-            ))
+    if crate.dep_kind == "registry" then
+        if api_crate then
+            if api_crate.name ~= crate:package() then
+                table.insert(diagnostics, crate_diagnostic(
+                    crate,
+                    "crate_name_case",
+                    vim.diagnostic.severity.ERROR,
+                    nil,
+                    { crate = crate, crate_name = api_crate.name }
+                ))
+            end
         end
-    end
 
-    if info.dep_kind == "registry" then
         if  newest then
             if semver.matches_requirements(newest.parsed, crate:vers_reqs()) then
                 -- version matches, no upgrade available

--- a/teal/crates/toml.tl
+++ b/teal/crates/toml.tl
@@ -36,6 +36,7 @@ local record M
         def: Def
         feat: Feat
         section: Section
+        dep_kind: DepKind
 
         enum Syntax
             "plain"
@@ -135,6 +136,13 @@ local record M
         end
     end
 
+    enum DepKind
+        "registry"
+        "path"
+        "git"
+        "workspace"
+    end
+
     record Feature
         name: string
         col: Range -- relative to to the start of the features text
@@ -195,6 +203,16 @@ function Crate.new(obj: Crate): Crate
     end
     if obj.opt then
         obj.opt.enabled = obj.opt.text ~= "false"
+    end
+
+    if obj.workspace then
+        obj.dep_kind = "workspace"
+    elseif obj.path then
+        obj.dep_kind = "path"
+    elseif obj.git then
+        obj.dep_kind = "git"
+    else
+        obj.dep_kind = "registry"
     end
 
     return setmetatable(obj, { __index = Crate })

--- a/teal/crates/types.tl
+++ b/teal/crates/types.tl
@@ -6,7 +6,6 @@ local record M
         vers_update: Version
         vers_upgrade: Version
         match_kind: MatchKind
-        dep_kind: DepKind
     end
 
     enum MatchKind
@@ -14,13 +13,6 @@ local record M
         "yanked"
         "prerelease"
         "nomatch"
-    end
-
-    enum DepKind
-        "registry"
-        "path"
-        "git"
-        "workspace"
     end
 
     record Diagnostic

--- a/teal/crates/ui.tl
+++ b/teal/crates/ui.tl
@@ -67,11 +67,7 @@ function M.display_crate_info(buf: integer, info: CrateInfo, diagnostics: {Diagn
         })
     end
 
-    if info.dep_kind == "path" then
-        -- TODO: display relevant information
-    elseif info.dep_kind == "git" then
-        -- TODO: display relevant information
-    elseif info.dep_kind == "registry" and not (info.vers_match or info.vers_upgrade) then
+    if not (info.vers_match or info.vers_upgrade) then
         table.insert(virt_text, {
              state.cfg.text.error,
              state.cfg.highlight.error,


### PR DESCRIPTION
Fixes #75. Since we currently can't resolve workspace, path, or git depencencies there is no guarantee that any crate with the same name we would fetch from crates.io is in any way related to local dependency.