### PR TITLE
fix: completion triggered before update has started

### DIFF
--- a/lua/crates/src/common.lua
+++ b/lua/crates/src/common.lua
@@ -147,9 +147,9 @@ local function complete()
 end
 
 function M.complete(callback)
-   async.launch(function()
+   vim.schedule(async.wrap(function()
       callback(complete())
-   end)
+   end))
 end
 
 return M

--- a/teal/crates/src/common.tl
+++ b/teal/crates/src/common.tl
@@ -147,9 +147,9 @@ local function complete(): CompletionList|nil
 end
 
 function M.complete(callback: function(CompletionList|nil))
-    async.launch(function()
+    vim.schedule(async.wrap(function()
         callback(complete())
-    end)
+    end))
 end
 
 return M


### PR DESCRIPTION
Fixes #79 

Schedule the completion call to the next event loop cycle to make sure update has been called even if the TextChanged autocmd of nvim-cmp has been called first.