### PR TITLE
feat: in-process lsp server

### DIFF
--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -235,6 +235,8 @@ For more information about individual config options see |crates-config|.
             enabled = false,
             name = "crates.nvim",
             on_attach = function(client, bufnr) end,
+            actions = false,
+            completion = false,
         },
     }
 <
@@ -1461,6 +1463,18 @@ lsp.on_attach                                    *crates-config-lsp-on_attach*
     Callback to run when the in-process language server attaches to a buffer.
 
     NOTE: Ignored if |crates-config-autoload| is disabled.
+
+
+lsp.actions                                        *crates-config-lsp-actions*
+    Type: `boolean`, Default: `false`
+
+    Whether to enable the `codeActionProvider` capability.
+
+
+lsp.completion                                  *crates-config-lsp-completion*
+    Type: `boolean`, Default: `false`
+
+    Whether to enable the `completionProvider` capability.
 
 
 

--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -83,13 +83,14 @@ For more information about individual config options see |crates-config|.
         loading_indicator = true,
         date_format = "%Y-%m-%d",
         thousands_separator = ".",
-        notification_title = "Crates",
+        notification_title = "crates.nvim",
         curl_args = { "-sL", "--retry", "1" },
         max_parallel_requests = 80,
         expand_crate_moves_cursor = true,
         open_programs = { "xdg-open", "open" },
         disable_invalid_feature_diagnostic = false,
         enable_update_available_warning = true,
+        on_attach = function(bufnr) end,
         text = {
             loading = "   Loading",
             version = "   %s",
@@ -223,14 +224,18 @@ For more information about individual config options see |crates-config|.
             },
             coq = {
                 enabled = false,
-                name = "Crates",
+                name = "crates.nvim",
             },
         },
         null_ls = {
             enabled = false,
-            name = "Crates",
+            name = "crates.nvim",
         },
-        on_attach = function(bufnr) end,
+        lsp = {
+            enabled = false,
+            name = "crates.nvim",
+            on_attach = function(client, bufnr) end,
+        },
     }
 <
 
@@ -566,7 +571,7 @@ thousands_separator                        *crates-config-thousands_separator*
 
 
 notification_title                          *crates-config-notification_title*
-    Type: `string`, Default: `"Crates"`
+    Type: `string`, Default: `"crates.nvim"`
 
     The title displayed in notifications.
 
@@ -608,6 +613,14 @@ enable_update_available_warning
     Type: `boolean`, Default: `true`
 
     Enable warnings for outdated crates.
+
+
+on_attach                                            *crates-config-on_attach*
+    Type: `function`, Default: `function(bufnr) end`
+
+    Callback to run when a `Cargo.toml` file is opened.
+
+    NOTE: Ignored if |crates-config-autoload| is disabled.
 
 
 avoid_prerelease                              *crates-config-avoid_prerelease*
@@ -1401,7 +1414,7 @@ src.coq.enabled                                *crates-config-src-coq-enabled*
 
 
 src.coq.name                                      *crates-config-src-coq-name*
-    Type: `string`, Default: `"Crates"`
+    Type: `string`, Default: `"crates.nvim"`
 
     The source name displayed by |coq_nvim|.
 
@@ -1419,17 +1432,35 @@ null_ls.enabled                                *crates-config-null_ls-enabled*
 
 
 null_ls.name                                      *crates-config-null_ls-name*
-    Type: `string`, Default: `"Crates"`
+    Type: `string`, Default: `"crates.nvim"`
 
     The |null-ls.nvim| name.
 
 
-on_attach                                            *crates-config-on_attach*
-    Type: `function`, Default: `function(bufnr) end`
+lsp                                                        *crates-config-lsp*
+    Type: `section`
 
-  Callback to run when a `Cargo.toml` file is opened.
+    Configuration options for the in-process language server.
 
-  NOTE: Ignored if |crates-config-autoload| is disabled.
+
+lsp.enabled                                        *crates-config-lsp-enabled*
+    Type: `boolean`, Default: `false`
+
+    Whether to enable the in-process language server.
+
+
+lsp.name                                              *crates-config-lsp-name*
+    Type: `string`, Default: `"crates.nvim"`
+
+    The lsp server name.
+
+
+lsp.on_attach                                    *crates-config-lsp-on_attach*
+    Type: `function`, Default: `function(client, bufnr) end`
+
+    Callback to run when the in-process language server attaches to a buffer.
+
+    NOTE: Ignored if |crates-config-autoload| is disabled.
 
 
 

--- a/docgen/templates/documentation.md.in
+++ b/docgen/templates/documentation.md.in
@@ -2,6 +2,7 @@ Documentation for `crates.nvim` `<VERSION>`
 
 # Features
 - Complete crate versions and features
+- In-process language server
 - Completion sources for:
     - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
     - [coq.nvim](https://github.com/ms-jpq/coq_nvim)
@@ -27,6 +28,24 @@ Documentation for `crates.nvim` `<VERSION>`
     - Indicate if a dependency is optional
 
 # Setup
+
+## lsp
+Enable the in-process language server in the setup and select whether to enable
+code actions and auto completion.
+```lua
+require("crates").setup {
+    ...
+    lsp = {
+        enabled = true,
+        on_attach = function(client, bufnr)
+            -- the same on_attach function as for your other lsp's
+        end,
+        actions = true,
+        completion = true,
+    },
+}
+```
+
 ## Auto completion
 ### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
 

--- a/docgen/wiki/Unstable-documentation.md
+++ b/docgen/wiki/Unstable-documentation.md
@@ -269,6 +269,8 @@ require("crates").setup {
         enabled = false,
         name = "crates.nvim",
         on_attach = function(client, bufnr) end,
+        actions = false,
+        completion = false,
     },
 }
 ```

--- a/docgen/wiki/Unstable-documentation.md
+++ b/docgen/wiki/Unstable-documentation.md
@@ -117,13 +117,14 @@ require("crates").setup {
     loading_indicator = true,
     date_format = "%Y-%m-%d",
     thousands_separator = ".",
-    notification_title = "Crates",
+    notification_title = "crates.nvim",
     curl_args = { "-sL", "--retry", "1" },
     max_parallel_requests = 80,
     expand_crate_moves_cursor = true,
     open_programs = { "xdg-open", "open" },
     disable_invalid_feature_diagnostic = false,
     enable_update_available_warning = true,
+    on_attach = function(bufnr) end,
     text = {
         loading = "   Loading",
         version = "   %s",
@@ -257,14 +258,18 @@ require("crates").setup {
         },
         coq = {
             enabled = false,
-            name = "Crates",
+            name = "crates.nvim",
         },
     },
     null_ls = {
         enabled = false,
-        name = "Crates",
+        name = "crates.nvim",
     },
-    on_attach = function(bufnr) end,
+    lsp = {
+        enabled = false,
+        name = "crates.nvim",
+        on_attach = function(client, bufnr) end,
+    },
 }
 ```
 

--- a/docgen/wiki/Unstable-documentation.md
+++ b/docgen/wiki/Unstable-documentation.md
@@ -2,6 +2,7 @@ Documentation for `crates.nvim` `unstable`
 
 # Features
 - Complete crate versions and features
+- In-process language server
 - Completion sources for:
     - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
     - [coq.nvim](https://github.com/ms-jpq/coq_nvim)
@@ -27,6 +28,24 @@ Documentation for `crates.nvim` `unstable`
     - Indicate if a dependency is optional
 
 # Setup
+
+## lsp
+Enable the in-process language server in the setup and select whether to enable
+code actions and auto completion.
+```lua
+require("crates").setup {
+    ...
+    lsp = {
+        enabled = true,
+        on_attach = function(client, bufnr)
+            -- the same on_attach function as for your other lsp's
+        end,
+        actions = true,
+        completion = true,
+    },
+}
+```
+
 ## Auto completion
 ### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
 

--- a/lua/crates/config.lua
+++ b/lua/crates/config.lua
@@ -251,6 +251,8 @@ local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {
 
 
 
+
+
 local Config = M.Config
 local SchemaElement = M.SchemaElement
 local SchemaType = M.SchemaType
@@ -1518,6 +1520,20 @@ entry(schema_lsp, "on_attach", {
         Callback to run when the in-process language server attaches to a buffer.
 
         NOTE: Ignored if |crates-config-autoload| is disabled.
+    ]],
+})
+entry(schema_lsp, "actions", {
+   type = "boolean",
+   default = false,
+   description = [[
+        Whether to enable the `codeActionProvider` capability.
+    ]],
+})
+entry(schema_lsp, "completion", {
+   type = "boolean",
+   default = false,
+   description = [[
+        Whether to enable the `completionProvider` capability.
     ]],
 })
 

--- a/lua/crates/config.lua
+++ b/lua/crates/config.lua
@@ -1,4 +1,11 @@
-local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {}, PopupConfig = {}, PopupTextConfig = {}, PopupHighlightConfig = {}, PopupKeyConfig = {}, SrcConfig = {}, SrcTextConfig = {}, CoqConfig = {}, CmpConfig = {}, CmpKindTextConfig = {}, CmpKindHighlightConfig = {}, NullLsConfig = {}, }, SchemaElement = {Deprecated = {}, }, }
+local M = {Config = {TextConfig = {}, HighlightConfig = {}, DiagnosticConfig = {}, PopupConfig = {}, PopupTextConfig = {}, PopupHighlightConfig = {}, PopupKeyConfig = {}, SrcConfig = {}, SrcTextConfig = {}, CoqConfig = {}, CmpConfig = {}, CmpKindTextConfig = {}, CmpKindHighlightConfig = {}, NullLsConfig = {}, LspConfig = {}, }, SchemaElement = {Deprecated = {}, }, }
+
+
+
+
+
+
+
 
 
 
@@ -331,7 +338,7 @@ entry(M.schema, "thousands_separator", {
 })
 entry(M.schema, "notification_title", {
    type = "string",
-   default = "Crates",
+   default = "crates.nvim",
    description = [[
         The title displayed in notifications.
     ]],
@@ -378,6 +385,16 @@ entry(M.schema, "enable_update_available_warning", {
    default = true,
    description = [[
         Enable warnings for outdated crates.
+    ]],
+})
+entry(M.schema, "on_attach", {
+   type = "function",
+   default = function(_bufnr) end,
+   default_text = "function(bufnr) end",
+   description = [[
+        Callback to run when a `Cargo.toml` file is opened.
+
+        NOTE: Ignored if |crates-config-autoload| is disabled.
     ]],
 })
 
@@ -1440,7 +1457,7 @@ entry(schema_src_coq, "enabled", {
 })
 entry(schema_src_coq, "name", {
    type = "string",
-   default = "Crates",
+   default = "crates.nvim",
    description = [[
         The source name displayed by |coq_nvim|.
     ]],
@@ -1464,22 +1481,46 @@ entry(schema_null_ls, "enabled", {
 })
 entry(schema_null_ls, "name", {
    type = "string",
-   default = "Crates",
+   default = "crates.nvim",
    description = [[
         The |null-ls.nvim| name.
     ]],
 })
 
-entry(M.schema, "on_attach", {
-   type = "function",
-   default = function(_bufnr) end,
-   default_text = "function(bufnr) end",
-   description = [[
-      Callback to run when a `Cargo.toml` file is opened.
 
-      NOTE: Ignored if |crates-config-autoload| is disabled.
+entry(M.schema, "lsp", {
+   type = "section",
+   description = [[
+        Configuration options for the in-process language server.
+    ]],
+   fields = {},
+})
+local schema_lsp = M.schema.lsp.fields
+entry(schema_lsp, "enabled", {
+   type = "boolean",
+   default = false,
+   description = [[
+        Whether to enable the in-process language server.
     ]],
 })
+entry(schema_lsp, "name", {
+   type = "string",
+   default = "crates.nvim",
+   description = [[
+        The lsp server name.
+    ]],
+})
+entry(schema_lsp, "on_attach", {
+   type = "function",
+   default = function(_client, _bufnr) end,
+   default_text = "function(client, bufnr) end",
+   description = [[
+        Callback to run when the in-process language server attaches to a buffer.
+
+        NOTE: Ignored if |crates-config-autoload| is disabled.
+    ]],
+})
+
 
 local function warn(s, ...)
    vim.notify(s:format(...), vim.log.levels.WARN, { title = "crates.nvim" })

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -82,6 +82,20 @@ local state = require("crates.state")
 
 
 
+
+function M.attach()
+   if state.cfg.src.cmp.enabled then
+      require("crates.src.cmp").setup()
+   end
+
+   if state.cfg.lsp.enabled then
+      require("crates.lsp").start_server()
+   end
+
+   core.update()
+   state.cfg.on_attach(vim.api.nvim_get_current_buf())
+end
+
 function M.setup(cfg)
    state.cfg = config.build(cfg)
 
@@ -91,24 +105,14 @@ function M.setup(cfg)
    local group = vim.api.nvim_create_augroup("Crates", {})
    if state.cfg.autoload then
       if vim.fn.expand("%:t") == "Cargo.toml" then
-         if state.cfg.src.cmp.enabled then
-            require("crates.src.cmp").setup()
-         end
-
-         core.update()
-         state.cfg.on_attach(vim.api.nvim_get_current_buf())
+         M.attach()
       end
 
       vim.api.nvim_create_autocmd("BufRead", {
          group = group,
          pattern = "Cargo.toml",
-         callback = function(info)
-            if state.cfg.src.cmp.enabled then
-               require("crates.src.cmp").setup()
-            end
-
-            core.update()
-            state.cfg.on_attach(info.buf)
+         callback = function(_)
+            M.attach()
          end,
       })
    end

--- a/lua/crates/lsp.lua
+++ b/lua/crates/lsp.lua
@@ -1,0 +1,139 @@
+local M = {Server = {}, ServerOpts = {}, CodeAction = {}, }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local Server = M.Server
+local CodeAction = M.CodeAction
+
+local actions = require("crates.actions")
+local util = require("crates.util")
+local state = require("crates.state")
+
+function M.server(opts)
+   opts = opts or {}
+   local capabilities = opts.capabilities or {}
+   local on_request = opts.on_request or function(_, _) end
+   local on_notify = opts.on_notify or function(_, _) end
+   local handlers = opts.handlers or {}
+
+   return function(dispatchers)
+      local closing = false
+      local srv = {}
+      local request_id = 0
+
+      function srv.request(method, params, callback)
+         pcall(on_request, method, params)
+         local handler = handlers[method]
+         if handler then
+            local response, err = handler(method, params)
+            callback(err, response)
+         elseif method == "initialize" then
+            callback(nil, {
+               capabilities = capabilities,
+            })
+         elseif method == "shutdown" then
+            callback(nil, nil)
+         end
+         request_id = request_id + 1
+         return true, request_id
+      end
+
+      function srv.notify(method, params)
+         pcall(on_notify, method, params)
+         if method == "exit" then
+            dispatchers.on_exit(0, 15)
+         end
+      end
+
+      function srv.is_closing()
+         return closing
+      end
+
+      function srv.terminate()
+         closing = true
+      end
+
+      return srv
+   end
+end
+
+function M.start_server()
+   local commands = {
+      "update_crate",
+      "upgrade_crate",
+      "expand_crate_to_inline_table",
+      "extract_crate_into_table",
+      "remove_duplicate_section",
+      "remove_original_section",
+      "remove_invalid_dependency_section",
+      "remove_duplicate_crate",
+      "remove_original_crate",
+      "rename_crate",
+      "remove_duplicate_feature",
+      "remove_original_feature",
+      "remove_invalid_feature",
+      "open_documentation",
+      "open_crates.io",
+      "update_all_crates",
+      "upgrade_all_crates",
+   }
+   for _, value in ipairs(commands) do
+      vim.lsp.commands[value] = function(cmd, ctx)
+         local action = actions.get_actions()[cmd.command]
+         if action then
+            vim.api.nvim_buf_call(ctx.bufnr, action)
+         else
+            util.notify(vim.log.levels.INFO, "Action not available '%s'", action)
+         end
+      end
+   end
+
+   local server = M.server({
+      capabilities = {
+         codeActionProvider = true,
+      },
+      handlers = {
+
+         ["textDocument/codeAction"] = function(_, _)
+            local code_actions = {}
+            for key, _ in pairs(actions.get_actions()) do
+               table.insert(code_actions, {
+                  title = util.format_title(key),
+                  kind = "refactor.rewrite",
+                  command = key,
+               })
+            end
+            return code_actions
+         end,
+      },
+   })
+   local client_id = vim.lsp.start({ name = state.cfg.lsp.name, cmd = server })
+   if not client_id then
+      return
+   end
+
+   local client = vim.lsp.get_client_by_id(client_id)
+   if not client then
+      return
+   end
+
+   local buf = vim.api.nvim_get_current_buf()
+   state.cfg.lsp.on_attach(client, buf)
+end
+
+return M

--- a/lua/crates/null-ls.lua
+++ b/lua/crates/null-ls.lua
@@ -13,10 +13,6 @@ end
 local null_ls_methods = require("null-ls.methods")
 local CODE_ACTION = null_ls_methods.internal.CODE_ACTION
 
-local function format_title(name)
-   return name:sub(1, 1):upper() .. name:gsub("_", " "):sub(2)
-end
-
 function M.source(name)
    return {
       name = name,
@@ -36,7 +32,7 @@ function M.source(name)
             local items = {}
             for key, action in pairs(actions.get_actions()) do
                table.insert(items, {
-                  title = format_title(key),
+                  title = util.format_title(key),
                   action = function()
                      vim.api.nvim_buf_call(params.bufnr, action)
                   end,

--- a/lua/crates/src/cmp.lua
+++ b/lua/crates/src/cmp.lua
@@ -101,7 +101,7 @@ end
 
 
 function M:get_trigger_characters(_)
-   return { '"', "'", ".", "<", ">", "=", "^", "~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" }
+   return src.trigger_characters
 end
 
 

--- a/lua/crates/src/common.lua
+++ b/lua/crates/src/common.lua
@@ -21,6 +21,8 @@ local M = {CompletionList = {}, CompletionItem = {}, CmpCompletionExtension = {}
 
 
 
+
+
 local CompletionItem = M.CompletionItem
 local CompletionList = M.CompletionList
 
@@ -33,6 +35,12 @@ local types = require("crates.types")
 local Range = types.Range
 local Version = types.Version
 local util = require("crates.util")
+
+M.trigger_characters = {
+   '"', "'", ".", "<", ">", "=", "^", "~",
+   "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
+}
+
 
 local VALUE_KIND = 12
 

--- a/lua/crates/util.lua
+++ b/lua/crates/util.lua
@@ -179,4 +179,8 @@ function M.open_url(url)
    M.notify(vim.log.levels.WARN, "Couldn't open url")
 end
 
+function M.format_title(name)
+   return name:sub(1, 1):upper() .. name:gsub("_", " "):sub(2)
+end
+
 return M

--- a/teal/crates/config.tl
+++ b/teal/crates/config.tl
@@ -17,13 +17,14 @@ local record M
         expand_crate_moves_cursor: boolean
         disable_invalid_feature_diagnostic: boolean
         enable_update_available_warning: boolean
+        on_attach: function(bufnr: integer): nil
         text: TextConfig
         highlight: HighlightConfig
         diagnostic: DiagnosticConfig
         popup: PopupConfig
         src: SrcConfig
         null_ls: NullLsConfig
-        on_attach: function(bufnr: integer): nil
+        lsp: LspConfig
 
         record TextConfig
             loading: string
@@ -214,6 +215,12 @@ local record M
             enabled: boolean
             name: string
         end
+
+        record LspConfig
+            enabled: boolean
+            name: string
+            on_attach: function(client: {string:any}, bufnr: integer): nil
+        end
     end
 
     enum SchemaType
@@ -331,7 +338,7 @@ entry(M.schema, "thousands_separator", {
 })
 entry(M.schema, "notification_title", {
     type = "string",
-    default = "Crates",
+    default = "crates.nvim",
     description = [[
         The title displayed in notifications.
     ]],
@@ -378,6 +385,16 @@ entry(M.schema, "enable_update_available_warning", {
     default = true,
     description = [[
         Enable warnings for outdated crates.
+    ]],
+})
+entry(M.schema, "on_attach", {
+    type = "function",
+    default = function(_bufnr) end,
+    default_text = "function(bufnr) end",
+    description = [[
+        Callback to run when a `Cargo.toml` file is opened.
+
+        NOTE: Ignored if |crates-config-autoload| is disabled.
     ]],
 })
 -- deprecated
@@ -1440,7 +1457,7 @@ entry(schema_src_coq, "enabled", {
 })
 entry(schema_src_coq, "name", {
     type = "string",
-    default = "Crates",
+    default = "crates.nvim",
     description = [[
         The source name displayed by |coq_nvim|.
     ]],
@@ -1464,22 +1481,46 @@ entry(schema_null_ls, "enabled", {
 })
 entry(schema_null_ls, "name", {
     type = "string",
-    default = "Crates",
+    default = "crates.nvim",
     description = [[
         The |null-ls.nvim| name.
     ]],
 })
 
-entry(M.schema, "on_attach", {
-    type = "function",
-    default = function(_bufnr) end,
-    default_text = "function(bufnr) end",
-    description = [[
-      Callback to run when a `Cargo.toml` file is opened.
 
-      NOTE: Ignored if |crates-config-autoload| is disabled.
+entry(M.schema, "lsp", {
+    type = "section",
+    description = [[
+        Configuration options for the in-process language server.
+    ]],
+    fields = {},
+})
+local schema_lsp = M.schema.lsp.fields
+entry(schema_lsp, "enabled", {
+    type = "boolean",
+    default = false,
+    description = [[
+        Whether to enable the in-process language server.
     ]],
 })
+entry(schema_lsp, "name", {
+    type = "string",
+    default = "crates.nvim",
+    description = [[
+        The lsp server name.
+    ]],
+})
+entry(schema_lsp, "on_attach", {
+    type = "function",
+    default = function(_client, _bufnr) end,
+    default_text = "function(client, bufnr) end",
+    description = [[
+        Callback to run when the in-process language server attaches to a buffer.
+
+        NOTE: Ignored if |crates-config-autoload| is disabled.
+    ]],
+})
+
 
 local function warn(s: string, ...:any)
     vim.notify(s:format(...), vim.log.levels.WARN, { title = "crates.nvim" })

--- a/teal/crates/config.tl
+++ b/teal/crates/config.tl
@@ -220,6 +220,8 @@ local record M
             enabled: boolean
             name: string
             on_attach: function(client: {string:any}, bufnr: integer): nil
+            actions: boolean
+            completion: boolean
         end
     end
 
@@ -1518,6 +1520,20 @@ entry(schema_lsp, "on_attach", {
         Callback to run when the in-process language server attaches to a buffer.
 
         NOTE: Ignored if |crates-config-autoload| is disabled.
+    ]],
+})
+entry(schema_lsp, "actions", {
+    type = "boolean",
+    default = false,
+    description = [[
+        Whether to enable the `codeActionProvider` capability.
+    ]],
+})
+entry(schema_lsp, "completion", {
+    type = "boolean",
+    default = false,
+    description = [[
+        Whether to enable the `completionProvider` capability.
     ]],
 })
 

--- a/teal/crates/init.tl
+++ b/teal/crates/init.tl
@@ -82,6 +82,20 @@ local record AutocmdInfo
   buf: integer
 end
 
+
+function M.attach()
+    if state.cfg.src.cmp.enabled then
+        require("crates.src.cmp").setup()
+    end
+
+    if state.cfg.lsp.enabled then
+        require("crates.lsp").start_server()
+    end
+
+    core.update()
+    state.cfg.on_attach(vim.api.nvim_get_current_buf())
+end
+
 function M.setup(cfg: Config)
     state.cfg = config.build(cfg)
 
@@ -91,24 +105,14 @@ function M.setup(cfg: Config)
     local group = vim.api.nvim_create_augroup("Crates", {})
     if state.cfg.autoload then
         if vim.fn.expand("%:t") == "Cargo.toml" then
-            if state.cfg.src.cmp.enabled then
-                require("crates.src.cmp").setup()
-            end
-
-            core.update()
-            state.cfg.on_attach(vim.api.nvim_get_current_buf())
+            M.attach()
         end
 
         vim.api.nvim_create_autocmd("BufRead", {
             group = group,
             pattern = "Cargo.toml",
-            callback = function(info: AutocmdInfo)
-                if state.cfg.src.cmp.enabled then
-                    require("crates.src.cmp").setup()
-                end
-
-                core.update()
-                state.cfg.on_attach(info.buf)
+            callback = function(_: AutocmdInfo)
+                M.attach()
             end,
         })
     end

--- a/teal/crates/lsp.tl
+++ b/teal/crates/lsp.tl
@@ -1,0 +1,139 @@
+local record M
+    record Server
+
+    end
+
+    record ServerOpts
+        handlers: {string:function(method: string, params: any): any}
+        on_request: function(method: string, params: any)
+        on_notify: function(method: string, params: any)
+        capabilities: table
+    end
+
+    record CodeAction
+        title: string
+        kind: string
+        action: function
+    end
+end
+
+local Server = M.Server
+local CodeAction = M.CodeAction
+
+local actions = require("crates.actions")
+local util = require("crates.util")
+local state = require("crates.state")
+
+function M.server(opts: {string:any}): function(any)
+	opts = opts or {}
+	local capabilities = opts.capabilities or {}
+	local on_request = opts.on_request as function or function(_, _) end
+	local on_notify = opts.on_notify as function or function(_, _) end
+	local handlers: {string:function} = opts.handlers as {string:function} or {}
+
+	return function(dispatchers: {string:function}): Server
+		local closing = false
+		local srv = {}
+		local request_id = 0
+
+		function srv.request(method: string, params: any, callback: function): boolean, integer
+			pcall(on_request, method, params)
+			local handler = handlers[method]
+			if handler then
+				local response, err = handler(method, params)
+				callback(err, response)
+			elseif method == "initialize" then
+				callback(nil, {
+					capabilities = capabilities,
+				})
+			elseif method == "shutdown" then
+				callback(nil, nil)
+			end
+			request_id = request_id + 1
+			return true, request_id
+		end
+
+		function srv.notify(method: string, params: any)
+			pcall(on_notify, method, params)
+			if method == "exit" then
+				dispatchers.on_exit(0, 15)
+			end
+		end
+
+		function srv.is_closing(): boolean
+			return closing
+		end
+
+		function srv.terminate()
+			closing = true
+		end
+
+		return srv
+	end
+end
+
+function M.start_server()
+	local commands = {
+		"update_crate",
+		"upgrade_crate",
+		"expand_crate_to_inline_table",
+		"extract_crate_into_table",
+		"remove_duplicate_section",
+		"remove_original_section",
+		"remove_invalid_dependency_section",
+		"remove_duplicate_crate",
+		"remove_original_crate",
+		"rename_crate",
+		"remove_duplicate_feature",
+		"remove_original_feature",
+		"remove_invalid_feature",
+		"open_documentation",
+		"open_crates.io",
+		"update_all_crates",
+		"upgrade_all_crates",
+	}
+	for _, value in ipairs(commands) do
+		vim.lsp.commands[value] = function(cmd: {string:any}, ctx: {string:any})
+			local action = actions.get_actions()[cmd.command as string]
+            if action then
+                vim.api.nvim_buf_call(ctx.bufnr as integer, action)
+            else
+                util.notify(vim.log.levels.INFO, "Action not available '%s'", action)
+            end
+		end
+	end
+
+	local server = M.server({
+		capabilities = {
+			codeActionProvider = true,
+		},
+		handlers = {
+			---@param params lsp.CodeActionParams
+			["textDocument/codeAction"] = function(_, _): {CodeAction}
+				local code_actions = {}
+				for key, _ in pairs(actions.get_actions()) do
+					table.insert(code_actions, {
+						title = util.format_title(key),
+						kind = "refactor.rewrite",
+						command = key,
+					})
+				end
+				return code_actions
+			end,
+		},
+	})
+	local client_id = vim.lsp.start({ name = state.cfg.lsp.name, cmd = server })
+    if not client_id then
+        return
+    end
+        
+    local client = vim.lsp.get_client_by_id(client_id)
+    if not client then
+        return
+    end
+
+    local buf = vim.api.nvim_get_current_buf() as integer
+    state.cfg.lsp.on_attach(client, buf)
+end
+
+return M

--- a/teal/crates/lsp.tl
+++ b/teal/crates/lsp.tl
@@ -15,10 +15,17 @@ local record M
         kind: string
         action: function
     end
+
+    record Command
+        title: string
+        command: string
+        arguments: {function}
+    end
 end
 
 local Server = M.Server
 local CodeAction = M.CodeAction
+local Command = M.Command
 
 local actions = require("crates.actions")
 local util = require("crates.util")
@@ -73,35 +80,16 @@ function M.server(opts: {string:any}): function(any)
 end
 
 function M.start_server()
-	local commands = {
-		"update_crate",
-		"upgrade_crate",
-		"expand_crate_to_inline_table",
-		"extract_crate_into_table",
-		"remove_duplicate_section",
-		"remove_original_section",
-		"remove_invalid_dependency_section",
-		"remove_duplicate_crate",
-		"remove_original_crate",
-		"rename_crate",
-		"remove_duplicate_feature",
-		"remove_original_feature",
-		"remove_invalid_feature",
-		"open_documentation",
-		"open_crates.io",
-		"update_all_crates",
-		"upgrade_all_crates",
-	}
-	for _, value in ipairs(commands) do
-		vim.lsp.commands[value] = function(cmd: {string:any}, ctx: {string:any})
-			local action = actions.get_actions()[cmd.command as string]
+    local commands = {
+        ["crates_command"] = function(cmd: Command, ctx: {string:any})
+            local action = cmd.arguments[1]
             if action then
                 vim.api.nvim_buf_call(ctx.bufnr as integer, action)
             else
                 util.notify(vim.log.levels.INFO, "Action not available '%s'", action)
             end
-		end
-	end
+        end
+    }
 
 	local server = M.server({
 		capabilities = {
@@ -111,22 +99,31 @@ function M.start_server()
 			---@param params lsp.CodeActionParams
 			["textDocument/codeAction"] = function(_, _): {CodeAction}
 				local code_actions = {}
-				for key, _ in pairs(actions.get_actions()) do
+				for key, action in pairs(actions.get_actions()) do
+                    local title = util.format_title(key)
 					table.insert(code_actions, {
-						title = util.format_title(key),
+						title = title,
 						kind = "refactor.rewrite",
-						command = key,
+						command = {
+                            title = title,
+                            command = key,
+                            arguments = { action },
+                        },
 					})
 				end
 				return code_actions
 			end,
 		},
 	})
-	local client_id = vim.lsp.start({ name = state.cfg.lsp.name, cmd = server })
+	local client_id = vim.lsp.start({
+        name = state.cfg.lsp.name,
+        cmd = server,
+        commands = commands,
+    })
     if not client_id then
         return
     end
-        
+
     local client = vim.lsp.get_client_by_id(client_id)
     if not client then
         return

--- a/teal/crates/lsp.tl
+++ b/teal/crates/lsp.tl
@@ -30,6 +30,7 @@ local Command = M.Command
 local actions = require("crates.actions")
 local util = require("crates.util")
 local state = require("crates.state")
+local src = require("crates.src.common")
 
 function M.server(opts: {string:any}): function(any)
 	opts = opts or {}
@@ -47,8 +48,7 @@ function M.server(opts: {string:any}): function(any)
 			pcall(on_request, method, params)
 			local handler = handlers[method]
 			if handler then
-				local response, err = handler(method, params)
-				callback(err, response)
+				handler(method, params, callback)
 			elseif method == "initialize" then
 				callback(nil, {
 					capabilities = capabilities,
@@ -93,11 +93,13 @@ function M.start_server()
 
 	local server = M.server({
 		capabilities = {
-			codeActionProvider = true,
+			codeActionProvider = state.cfg.lsp.actions,
+            completionProvider = state.cfg.lsp.completion and {
+                triggerCharacters = src.trigger_characters,
+            },
 		},
 		handlers = {
-			---@param params lsp.CodeActionParams
-			["textDocument/codeAction"] = function(_, _): {CodeAction}
+			["textDocument/codeAction"] = function(_, _, callback: function(err: nil, actions: {CodeAction}))
 				local code_actions = {}
 				for key, action in pairs(actions.get_actions()) do
                     local title = util.format_title(key)
@@ -111,7 +113,12 @@ function M.start_server()
                         },
 					})
 				end
-				return code_actions
+				callback(nil, code_actions)
+			end,
+			["textDocument/completion"] = function(_, _, callback: function(err: nil, items: src.CompletionList|nil))
+                src.complete(function(items: src.CompletionList|nil)
+                    callback(nil, items)
+                end)
 			end,
 		},
 	})

--- a/teal/crates/null-ls.tl
+++ b/teal/crates/null-ls.tl
@@ -13,10 +13,6 @@ end
 local null_ls_methods = require("null-ls.methods")
 local CODE_ACTION = null_ls_methods.internal.CODE_ACTION
 
-local function format_title(name: string): string
-    return name:sub(1, 1):upper() .. name:gsub("_", " "):sub(2)
-end
-
 function M.source(name: string): null_ls.Source
     return {
         name = name,
@@ -36,7 +32,7 @@ function M.source(name: string): null_ls.Source
                 local items: {null_ls.Action} = {}
                 for key,action in pairs(actions.get_actions()) do
                     table.insert(items, {
-                        title = format_title(key),
+                        title = util.format_title(key),
                         action = function()
                             vim.api.nvim_buf_call(params.bufnr, action)
                         end,

--- a/teal/crates/src/cmp.tl
+++ b/teal/crates/src/cmp.tl
@@ -101,7 +101,7 @@ end
 
 ---Return trigger characters.
 function M:get_trigger_characters(_: M.cmp.SourceBaseApiParams): {string}
-    return { '"', "'", ".", "<", ">", "=", "^", "~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" }
+    return src.trigger_characters
 end
 
 ---Invoke completion (required).

--- a/teal/crates/src/common.tl
+++ b/teal/crates/src/common.tl
@@ -1,4 +1,6 @@
 local record M
+    trigger_characters: {string}
+
     record CompletionList
         isIncomplete: boolean
         items: {CompletionItem}
@@ -34,6 +36,12 @@ local Range = types.Range
 local Version = types.Version
 local util = require("crates.util")
 
+M.trigger_characters = {
+    '"', "'", ".", "<", ">", "=", "^", "~",
+    "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
+}
+
+-- lsp CompletionItemKind.Value
 local VALUE_KIND = 12
 
 local function complete_versions(crate: toml.Crate, versions: {Version}): CompletionList

--- a/teal/crates/util.tl
+++ b/teal/crates/util.tl
@@ -179,4 +179,8 @@ function M.open_url(url: string)
     M.notify(vim.log.levels.WARN, "Couldn't open url")
 end
 
+function M.format_title(name: string): string
+    return name:sub(1, 1):upper() .. name:gsub("_", " "):sub(2)
+end
+
 return M

--- a/types/vim.d.tl
+++ b/types/vim.d.tl
@@ -488,6 +488,10 @@ global record vim
       buf_request: function(bufnr: integer, method: string, params: table, handler: function): {integer:integer}, function
       buf_request_sync: function(bufnr: integer, method: string, params: table, timeout_ms: integer): {integer:integer}, string
 
+      start: function(config: {string: any}, opts: {string:any}): integer
+      get_client_by_id: function(integer): {string:any}
+      commands: {string:function}
+
       record Client
          request: function(Client)
       end


### PR DESCRIPTION
As mentioned in #78, this implements an in-process lsp server.
it can be enabled in the configuration:
```lua
require("crates").setup({
    lsp = {
        enable = true,
        on_attach = function(client, buf) end,
    }
})
```
`on_attach` can be the same function as passed to any other language servers.

- [x] code actions
- [x] completion
- [x] documentation