### PR TITLE
Compare the workspace kind against the enum value, not a string.

### DIFF
--- a/lua/crates/diagnostic.lua
+++ b/lua/crates/diagnostic.lua
@@ -127,7 +127,7 @@ function M.process_crates(sections, crates)
     for _, s in ipairs(sections) do
         local key = s.text:gsub("%s+", "")
 
-        if s.workspace and s.kind ~= "default" then
+        if s.workspace and s.kind ~= toml.TomlSectionKind.DEFAULT then
             table.insert(diagnostics, section_diagnostic(
                 s,
                 CratesDiagnosticKind.WORKSPACE_SECTION_NOT_DEFAULT,


### PR DESCRIPTION
I was getting a warning when editing a workspace `Cargo.toml` file that didn't make sense.

This should fix it.

```toml
[workspace]
members = [ "crates/*" ]
resolver = "2"

[workspace.package]
edition = "2021"

[workspace.dependencies]
git2 = { version = "^0", default_features = false, features = [
    "https",
    "openssl-sys",
    "ssh",
    "vendored-libgit2",
] }
reqwest = { version = "^0", default_features = false, features = [
    "blocking",
    "cookies",
    "deflate",
    "gzip",
    "json",
    "rustls-tls",
] }
```