### PR TITLE
load local config from external toml file

### DIFF
--- a/lua/crates/core.lua
+++ b/lua/crates/core.lua
@@ -104,7 +104,6 @@ local function update(buf, reload)
     end
 
     local local_config = toml.parse_metadata(buf)
-    vim.print(local_config)
     local sections, crates = toml.parse_crates(buf)
     local crate_cache, diagnostics = diagnostic.process_crates(sections, crates)
     ---@type BufCache

--- a/lua/crates/core.lua
+++ b/lua/crates/core.lua
@@ -103,6 +103,8 @@ local function update(buf, reload)
         api.cancel_jobs()
     end
 
+    local local_config = toml.parse_metadata(buf)
+    vim.print(local_config)
     local sections, crates = toml.parse_crates(buf)
     local crate_cache, diagnostics = diagnostic.process_crates(sections, crates)
     ---@type BufCache
@@ -110,6 +112,7 @@ local function update(buf, reload)
         crates = crate_cache,
         info = {},
         diagnostics = diagnostics,
+        local_config = local_config,
     }
     state.buf_cache[buf] = cache
 

--- a/lua/crates/core.lua
+++ b/lua/crates/core.lua
@@ -103,7 +103,6 @@ local function update(buf, reload)
         api.cancel_jobs()
     end
 
-    local local_config = toml.parse_metadata(buf)
     local sections, crates = toml.parse_crates(buf)
     local crate_cache, diagnostics = diagnostic.process_crates(sections, crates)
     ---@type BufCache
@@ -111,7 +110,6 @@ local function update(buf, reload)
         crates = crate_cache,
         info = {},
         diagnostics = diagnostics,
-        local_config = local_config,
     }
     state.buf_cache[buf] = cache
 

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -10,6 +10,13 @@ local util = require("crates.util")
 local toml = require("crates.toml")
 
 local function attach()
+    local buf = util.current_buf()
+    local h = io.open('.crates.nvim.toml', 'r')
+    if h then
+        local local_config = toml.parse_local_config(h)
+        state.local_config[buf] = local_config
+    end
+
     if state.cfg.src.cmp.enabled then
         require("crates.src.cmp").setup()
     end
@@ -18,12 +25,6 @@ local function attach()
         require("crates.lsp").start_server()
     end
 
-    local buf = util.current_buf()
-    local h = io.open('.crates.nvim.toml', 'r')
-    if h then
-        local local_config = toml.parse_local_config(h)
-        state.local_config[buf] = local_config
-    end
     core.update()
     state.cfg.on_attach(buf)
 end

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -23,7 +23,7 @@ end
 
 ---@param cfg crates.UserConfig
 local function setup(cfg)
-    state.cfg = config.build(cfg)
+    state:set_cfg(config.build(cfg))
 
     command.register()
     highlight.define()

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -7,6 +7,7 @@ local highlight = require("crates.highlight")
 local popup = require("crates.popup")
 local state = require("crates.state")
 local util = require("crates.util")
+local toml = require("crates.toml")
 
 local function attach()
     if state.cfg.src.cmp.enabled then
@@ -17,8 +18,14 @@ local function attach()
         require("crates.lsp").start_server()
     end
 
+    local buf = util.current_buf()
+    local h = io.open('.crates.nvim.toml', 'r')
+    if h then
+        local local_config = toml.parse_local_config(h)
+        state.local_config[buf] = local_config
+    end
     core.update()
-    state.cfg.on_attach(util.current_buf())
+    state.cfg.on_attach(buf)
 end
 
 ---@param cfg crates.UserConfig

--- a/lua/crates/state.lua
+++ b/lua/crates/state.lua
@@ -1,5 +1,6 @@
 ---@class State
 ---@field cfg Config
+---@field _cfg Config
 ---@field api_cache table<string,ApiCrate>
 ---@field buf_cache table<integer,BufCache>
 ---@field visible boolean
@@ -9,10 +10,27 @@ local State = {
     visible = true,
 }
 
+---@param config Config
+function State:set_cfg(config)
+    self._cfg = config
+    self.cfg = setmetatable({}, {
+        __index = function (_, key)
+            ---@type integer
+            local buf = vim.api.nvim_get_current_buf()
+            local cache = self.buf_cache[buf]
+            if cache and cache.local_config and cache.local_config[key] then
+                return cache.local_config[key]
+            end
+            return self._cfg[key]
+        end
+    })
+end
+
 ---@class BufCache
 ---@field crates table<string,TomlCrate>
 ---@field info table<string,CrateInfo>
 ---@field diagnostics CratesDiagnostic[]
+---@field local_config crates.UserConfig?
 
 State.api_cache = {}
 State.buf_cache = {}

--- a/lua/crates/state.lua
+++ b/lua/crates/state.lua
@@ -3,11 +3,13 @@
 ---@field _cfg Config
 ---@field api_cache table<string,ApiCrate>
 ---@field buf_cache table<integer,BufCache>
+---@field local_config table<integer, crates.UserConfig>
 ---@field visible boolean
 local State = {
     api_cache = {},
     buf_cache = {},
     visible = true,
+    local_config = {},
 }
 
 ---@param config Config
@@ -17,9 +19,9 @@ function State:set_cfg(config)
         __index = function (_, key)
             ---@type integer
             local buf = vim.api.nvim_get_current_buf()
-            local cache = self.buf_cache[buf]
-            if cache and cache.local_config and cache.local_config[key] then
-                return cache.local_config[key]
+            local cfg = self.local_config[buf]
+            if cfg and cfg[key] then
+                return cfg[key]
             end
             return self._cfg[key]
         end
@@ -30,7 +32,6 @@ end
 ---@field crates table<string,TomlCrate>
 ---@field info table<string,CrateInfo>
 ---@field diagnostics CratesDiagnostic[]
----@field local_config crates.UserConfig?
 
 State.api_cache = {}
 State.buf_cache = {}

--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -910,7 +910,6 @@ local function parse_value(str)
     ---@type string
     local array = str:match '(%b[])'
     if array then
-        print("ara ara")
         ---@type table<string, any>
         local tbl = {}
         array = array:sub(2, #array - 1)

--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -932,7 +932,6 @@ function M.parse_metadata(buf)
             ---@cast current table<string, table>
             ---@cast current_real table<string, table>
             if section_text then
-                print(section_text)
                 for tbl in section_text:gmatch '%.([%w-_]+)' do
                     if current_real[tbl] then
                         current_real = current_real[tbl]


### PR DESCRIPTION
This allows you to set lsp settings in the `Cargo.toml`'s [package.metadata.lsp] attribute. Currently there isn't really any error handling. it just picks out everything it can that's valid and overlays it onto the main config.

My main motivation to implement this is another thing I'm working on that would add some more diagnostics, specifically to the [package] table, that someone may want to disable for a single package.

This is something I just cooked up the in last couple hours. if `[package.metadata.lsp]` doesn't seem like the right fit for a local config, then that can easily be changed