### PR TITLE
Fix freeze when parsing array tables

### DIFF
--- a/lua/crates/toml.lua
+++ b/lua/crates/toml.lua
@@ -760,7 +760,11 @@ function M.parse_crates(buf)
         line = M.trim_comments(line)
         local line_nr = i - 1
 
-        local section_start, section_text = line:match("^%s*%[()([^%]]+)%]?%s*$")
+        ---@type string, string
+        local section_start, section_text = line:match("^%s*%[()(.+)%s*$")
+        if section_text and section_text:sub(-1) == ']' then
+            section_text = section_text:sub(1, -2)
+        end
 
         if section_text then
             if dep_section then


### PR DESCRIPTION
It seems i was right to worry about accidentally breaking something with that last minor change, neovim started freezing whenever i tried to type in an array table because I fucked up the logic of parsing the table headers. I've done it much more carefully this time, so that shouldn't happen anymore