### PR TITLE
fix: Make command execution on windows work for non-exe open methods

### DIFF
--- a/lua/crates/util.lua
+++ b/lua/crates/util.lua
@@ -215,8 +215,8 @@ end
 ---@param url string
 function M.open_url(url)
     for _, prg in ipairs(state.cfg.open_programs) do
-        if M.binary_installed(prg) then
-            vim.cmd(string.format("silent !%s %s", prg, url))
+        local ok, result = pcall(vim.cmd, string.format("silent !%s %s", prg, url))
+        if ok == true then
             return
         end
     end


### PR DESCRIPTION
This should make is so that using "start" as an open_program in the config actually works on windows. it changes the executable check out for an try-catch basically.

<!-- Please use conventional commit messages for PR titles: https://www.conventionalcommits.org/en/v1.0.0 -->
