### PR TITLE
fix: sort fetched crate versions

### DIFF
--- a/lua/crates/api.lua
+++ b/lua/crates/api.lua
@@ -445,6 +445,13 @@ function M.parse_crate(index_json_str, meta_json)
         version.created = assert(DateTime.parse_rfc_3339(v.created_at))
         table.insert(crate.versions, version)
     end
+    -- sort versions
+    table.sort(crate.versions, function(a, b)
+        return semver.matches_requirement(a.parsed, {
+            cond = types.Cond.GT,
+            vers = b.parsed,
+        })
+    end)
 
     return crate
 end

--- a/lua/crates/api.lua
+++ b/lua/crates/api.lua
@@ -266,6 +266,26 @@ function M.fetch_search(name)
     end)
 end
 
+---@param a SemVer
+---@param b SemVer
+---@return boolean
+local function sort_semvers(a, b)
+    if a.major ~= b.major then
+        return a.major > b.major
+    end
+    if a.minor ~= b.minor then
+        return a.minor > b.minor
+    end
+    if a.patch ~= b.patch then
+        return a.patch > b.patch
+    end
+    local pre = semver.compare_pre(a.pre, b.pre)
+    if pre ~= 0 then
+        return pre > 0
+    end
+    return semver.compare_meta(a.meta, b.meta) > 0
+end
+
 ---@param a ApiFeature
 ---@param b ApiFeature
 ---@return boolean
@@ -447,10 +467,7 @@ function M.parse_crate(index_json_str, meta_json)
     end
     -- sort versions
     table.sort(crate.versions, function(a, b)
-        return semver.matches_requirement(a.parsed, {
-            cond = types.Cond.GT,
-            vers = b.parsed,
-        })
+        return sort_semvers(a.parsed, b.parsed)
     end)
 
     return crate

--- a/lua/crates/semver.lua
+++ b/lua/crates/semver.lua
@@ -200,10 +200,29 @@ function M.parse_requirements(str)
     return requirements
 end
 
----@param version string
----@param req string
+-- TODO: port https://github.com/dtolnay/semver/blob/master/src%2Fimpls.rs#L51-L107
+---@param version? string
+---@param req? string
 ---@return integer
-local function compare_pre(version, req)
+function M.compare_pre(version, req)
+    if version and req then
+        if version < req then
+            return -1
+        elseif version == req then
+            return 0
+        elseif version > req then
+            return 1
+        end
+    end
+
+    return (req and 1 or 0) - (version and 1 or 0)
+end
+
+-- TODO: port https://github.com/dtolnay/semver/blob/master/src/impls.rs#L109-L153
+---@param version? string
+---@param req? string
+---@return integer
+function M.compare_meta(version, req)
     if version and req then
         if version < req then
             return -1
@@ -231,7 +250,7 @@ local function matches_less(version, req)
         return version.patch < req.patch
     end
 
-    return compare_pre(version.pre, req.pre) < 0
+    return M.compare_pre(version.pre, req.pre) < 0
 end
 
 ---@param version SemVer
@@ -248,7 +267,7 @@ local function matches_greater(version, req)
         return version.patch > req.patch
     end
 
-    return compare_pre(version.pre, req.pre) > 0
+    return M.compare_pre(version.pre, req.pre) > 0
 end
 
 ---@param version SemVer
@@ -304,7 +323,7 @@ local function matches_caret(version, req)
         return false
     end
 
-    return compare_pre(version.pre, req.pre) >= 0
+    return M.compare_pre(version.pre, req.pre) >= 0
 end
 
 ---@param version SemVer
@@ -321,7 +340,7 @@ local function matches_tilde(version, req)
         return version.patch > req.patch
     end
 
-    return compare_pre(version.pre, req.pre) >= 0
+    return M.compare_pre(version.pre, req.pre) >= 0
 end
 
 ---@param v SemVer


### PR DESCRIPTION
<!-- Please use conventional commit messages for PR titles: https://www.conventionalcommits.org/en/v1.0.0 -->
First, thanks for this plugin! It's very useful.

The last updated version is not necessarily the latest version. (e.g., the latest version of [usbd-hid](https://crates.io/crates/usbd-hid/versions) is currently 0.8.2, but was last updated to 0.7.1).
This creates a warning diagnosis to the wrong latest version.

To solve this problem, the fetched crate versions are now sorted by semver.