### PR TITLE
fix: prevent update diagnostics from showing for matching pre-releases

### DIFF
--- a/lua/crates/diagnostic.lua
+++ b/lua/crates/diagnostic.lua
@@ -269,13 +269,18 @@ function M.process_api_crate(crate, api_crate, diagnostics)
         end
 
         if newest then
-            if semver.matches_requirements(newest.parsed, crate:vers_reqs()) then
-                -- version matches, no upgrade available
-                info.vers_match = newest
+            local newest_matches = semver.matches_requirements(newest.parsed, crate:vers_reqs())
+            local pre_matches = newest_pre and semver.matches_requirements(newest_pre.parsed, crate:vers_reqs())
+
+            if newest_matches or pre_matches then
+                -- matching release or pre-release found
+                local matched = pre_matches and newest_pre or newest
+
+                info.vers_match = matched
                 info.match_kind = MatchKind.VERSION
 
-                if crate.vers and crate.vers.text ~= edit.version_text(crate, newest.parsed) then
-                    info.vers_update = newest
+                if crate.vers and crate.vers.text ~= edit.version_text(crate, matched.parsed) then
+                    info.vers_update = matched
                 end
             else
                 -- version does not match, upgrade available

--- a/lua/crates/util.lua
+++ b/lua/crates/util.lua
@@ -111,15 +111,16 @@ end
 
 ---@param versions ApiVersion[]?
 ---@param reqs Requirement[]?
+---@param allow_pre boolean? -- fallback to use when `reqs` is nil
 ---@return ApiVersion?
 ---@return ApiVersion?
 ---@return ApiVersion?
-function M.get_newest(versions, reqs)
+function M.get_newest(versions, reqs, allow_pre)
     if not versions or not next(versions) then
         return nil
     end
 
-    local allow_pre = reqs and semver.allows_pre(reqs) or false
+    allow_pre = reqs and semver.allows_pre(reqs) or allow_pre or false
 
     ---@type ApiVersion?, ApiVersion?, ApiVersion?
     local newest_yanked, newest_pre, newest


### PR DESCRIPTION
When the user requests a pre-release (e.g. `crate = "1.0.0-alpha.3"`), an update diagnostic was shown to the user even if the requested pre-release was the newest release.

This makes sure that both `newest` and `newest_pre` are considered when checking if the newest found version is matched by the user's requirements.