### PR TITLE
feat: support nvim 0.11 winborder as popup.border

### DIFF
--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -118,7 +118,7 @@ For more information about individual config options see |crates-config|.
             hide_on_select = false,
             copy_register = '"',
             style = "minimal",
-            border = "none",
+            border = nil,
             show_version_date = false,
             show_dependency_version = true,
             max_height = 30,
@@ -822,9 +822,12 @@ popup.style                                        *crates-config-popup-style*
 
 
 popup.border                                      *crates-config-popup-border*
-    Type: `string|string[]`, Default: `"none"`
+    Type: `string|string[]`, Default: `nil`
 
     Same as nvim_open_win config.border.
+
+    If unset or nil, defaults to global 'winborder' on nvim >= 0.11.0, else
+    "none".
 
 
 popup.show_version_date                *crates-config-popup-show_version_date*

--- a/docgen/wiki/Documentation-unstable.md
+++ b/docgen/wiki/Documentation-unstable.md
@@ -276,7 +276,7 @@ require("crates").setup {
         hide_on_select = false,
         copy_register = '"',
         style = "minimal",
-        border = "none",
+        border = nil,
         show_version_date = false,
         show_dependency_version = true,
         max_height = 30,

--- a/lua/crates/config/init.lua
+++ b/lua/crates/config/init.lua
@@ -598,9 +598,11 @@ entry(schema_popup, {
         config_type = { "string", "table" },
         emmylua_annotation = "string|string[]",
     },
-    default = "none",
+    default = vim.opt_global.winborder:get(),
     description = [[
         Same as nvim_open_win config.border.
+
+        If unset, defaults to global |'winborder'|.
     ]],
 })
 entry(schema_popup, {

--- a/lua/crates/config/init.lua
+++ b/lua/crates/config/init.lua
@@ -598,11 +598,12 @@ entry(schema_popup, {
         config_type = { "string", "table" },
         emmylua_annotation = "string|string[]",
     },
-    default = vim.version.ge(vim.version(), {0, 11, 0}) and vim.opt_global.winborder:get() or "none",
+    default = nil,
     description = [[
         Same as nvim_open_win config.border.
 
-        If unset, defaults to global 'winborder' on nvim >= 0.11.0, else "none".
+        If unset or nil, defaults to global 'winborder' on nvim >= 0.11.0, else
+        "none".
     ]],
 })
 entry(schema_popup, {

--- a/lua/crates/config/init.lua
+++ b/lua/crates/config/init.lua
@@ -598,11 +598,11 @@ entry(schema_popup, {
         config_type = { "string", "table" },
         emmylua_annotation = "string|string[]",
     },
-    default = vim.opt_global.winborder:get(),
+    default = vim.version.ge(vim.version(), {0, 11, 0}) and vim.opt_global.winborder:get() or "none",
     description = [[
         Same as nvim_open_win config.border.
 
-        If unset, defaults to global |'winborder'|.
+        If unset, defaults to global 'winborder' on nvim >= 0.11.0, else "none".
     ]],
 })
 entry(schema_popup, {

--- a/lua/crates/popup/common.lua
+++ b/lua/crates/popup/common.lua
@@ -165,6 +165,22 @@ function M.update_win(width, height, title, text, opts)
     vim.api.nvim_win_set_cursor(M.win, { l, 0 })
 end
 
+--- Get the border of the popup menu.
+---
+--- Returns the first valid value out of the following choices (in that order):
+--- 1. Config value `popup.border`, if configured
+--- 2. Global `winborder`, if neovim version >= 0.11.0
+--- 3. `"none"`
+local function popup_border()
+    if state.cfg.popup.border ~= nil then
+        return state.cfg.popup.border
+    elseif vim.version.ge(vim.version(), {0, 11, 0}) then
+        return vim.opt_global.winborder:get()
+    else
+        return "none"
+    end
+end
+
 ---@param width integer
 ---@param height integer
 ---@param title string
@@ -185,7 +201,7 @@ function M.open_win(width, height, title, text, opts, configure)
         width = width,
         height = height,
         style = state.cfg.popup.style,
-        border = state.cfg.popup.border,
+        border = popup_border(),
     })
 
     -- add key mappings


### PR DESCRIPTION
Replace the default value for `popup.border` with whatever the global `winborder` setting added in nvim 0.11 is. If the neovim version is less than 0.11, default to "none" instead as before.

Previously the `winborder` setting was ignored and there was no way to override it, since the config is automatically filled up with the configured default values. I considered setting the default to `nil` and modifying the window code like this:

```diff
-        border = state.cfg.popup.border,
+        border = state.cfg.popup.border or vim.opt_global.winborder:get() or "none",
```

but that will fall apart if the border setting is ever used in a second location (or the code above must be replicated). Also the chosen approach of overwriting the default has the nice side-effect that users that haven't previously configured this setting will automatically have their `winborder` setting picked up.

The docs generation, since user-config isn't read, picks up the default for `border` as empty string (`""`), which is fine since according to the nvim docs it's equivalent to `"none"`. I hope that's okay though?