### PR TITLE
fix: Handle winborder:get return correctly

### DIFF
--- a/lua/crates/popup/common.lua
+++ b/lua/crates/popup/common.lua
@@ -175,7 +175,12 @@ local function popup_border()
     if state.cfg.popup.border ~= nil then
         return state.cfg.popup.border
     elseif vim.version.ge(vim.version(), {0, 11, 0}) then
-        return vim.opt_global.winborder:get()
+        ---@type string[]
+        local winborder = vim.opt_global.winborder:get()
+
+        -- This returns { "<value>" } if something like "single" or "rounded"
+        -- is set, or a list of border chars.
+        return #winborder == 1 and winborder[1] or winborder
     else
         return "none"
     end


### PR DESCRIPTION
Hey, from what I can tell `vim.opt_global:get` always returns a table, but `nvim_open_win` expects either a string for a preset or a table. If a table is passed, it will always get interpreted as a list of border chars, and we'll get `invalid number of border chars`.

This PR works around that by checking the length of `winborder:get` and transforming the value accordingly.
