### PR TITLE
feat!: deprecate the nvim-cmp, coq_nvim, and null-ls sources

### DIFF
--- a/doc/crates.txt
+++ b/doc/crates.txt
@@ -734,9 +734,6 @@ text.error                                          *crates-config-text-error*
     Format string used when there was an error loading crate information.
 
 
-open_programs                                    *crates-config-open_programs*
-    DEPRECATED: `vim.ui.open()` is used instead
-
 highlight                                            *crates-config-highlight*
     Section type: `HighlightConfig`
 
@@ -1414,6 +1411,7 @@ completion.cmp                                  *crates-config-completion-cmp*
 
 
 completion.cmp.enabled                  *crates-config-completion-cmp-enabled*
+    DEPRECATED: The nvim-cmp source will be removed soon. Use the in-process language server instead.
     Type: `boolean`, Default: `false`
 
     Whether to load and register the |nvim-cmp| source.
@@ -1478,6 +1476,7 @@ completion.coq                                  *crates-config-completion-coq*
 
 
 completion.coq.enabled                  *crates-config-completion-coq-enabled*
+    DEPRECATED: The coq_nvim source will be removed soon. Use the in-process language server instead.
     Type: `boolean`, Default: `false`
 
     Whether to load and register the |coq_nvim| source.
@@ -1590,21 +1589,24 @@ completion.crates.max_results    *crates-config-completion-crates-max_results*
 
 
 src                                                        *crates-config-src*
-    DEPRECATED: please use |crates-config-completion| instead.
-
+    DEPRECATED: This will be ignored.
+    Please use |crates-config-completion| instead.
 null_ls                                                *crates-config-null_ls*
+    DEPRECATED: The null-ls source will be removed soon. Use the in-process language server instead.
     Section type: `NullLsConfig`
 
     Configuration options for null-ls.nvim actions.
 
 
 null_ls.enabled                                *crates-config-null_ls-enabled*
+    DEPRECATED: The null-ls source will be removed soon. Use the in-process language server instead.
     Type: `boolean`, Default: `false`
 
     Whether to register the |null-ls.nvim| source.
 
 
 null_ls.name                                      *crates-config-null_ls-name*
+    DEPRECATED: The null-ls source will be removed soon. Use the in-process language server instead.
     Type: `string`, Default: `"crates.nvim"`
 
     The |null-ls.nvim| name.
@@ -1650,6 +1652,8 @@ lsp.on_attach                                    *crates-config-lsp-on_attach*
     Type: `fun(client: vim.lsp.Client, bufnr: integer)`, Default: `function(client, bufnr) end`
 
     Callback to run when the in-process language server attaches to a buffer.
+
+    NOTE: Alternatively you can also use the `LspAttach` autocmd.
 
     NOTE: Ignored if |crates-config-autoload| is disabled.
 

--- a/docgen/templates/documentation.md.in
+++ b/docgen/templates/documentation.md.in
@@ -1,13 +1,10 @@
 Documentation for `crates.nvim` `<VERSION>`
 
 # Features
-- Complete crate names, versions and features using one of:
-    - In-process language server (`lsp`)
-    - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source (`completion.cmp`)
-    - [coq.nvim](https://github.com/ms-jpq/coq_nvim) source (`completion.coq`)
-- Code actions using one of:
-    - In-process language server (`lsp`)
-    - [null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim)/[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim)
+- In-process language server (`lsp`)
+    - Complete crate names, versions and features
+    - Code actions
+    - Hover
 - Update crates to newest compatible version
 - Upgrade crates to newest version
 - Respect existing version requirements and update them in an elegant way (`smart_insert`)
@@ -31,10 +28,12 @@ Documentation for `crates.nvim` `<VERSION>`
 # Setup
 
 ## In-process language server
-This is the recommended way to enable completion and code actions.
+The in-process langauge server is disabled by default. It can be enabled
+to support completions, code actions, and hover.
 
 Enable the in-process language server in the setup and select whether to enable
-code actions, auto completion and hover.
+code actions, auto completion and hover. The `on_attach` function, or the `LspAttach`
+autocmd can be used to setup key mappings, just like for other language servers.
 ```lua
 require("crates").setup {
     ...
@@ -52,56 +51,30 @@ require("crates").setup {
 ```
 
 ## Auto completion
-Completion is supported in a few different ways, either by the [in-process language server](#in-process-language-server),
-which also supports code actions, or by one of the following sources.
+Auto completion works through the [in-process language server](#in-process-language-server).
 
-### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
+### Crate name completion
 
-Enable it in the setup.
+Crate names of dependencies can be completed from searches on `crates.io`.
+This has to be enabled seperately:
+
 ```lua
 require("crates").setup {
     ...
     completion = {
-        ...
-        cmp = {
-            enabled = true,
-        },
-    },
+        crates = {
+            enabled = true -- Disabled by default
+            max_results = 8 -- The maximum number of search results to display
+            min_chars = 3 -- The minimum number of charaters to type before completions begin appearing
+        }
+    }
 }
 ```
 
-And add it to your list of sources.
-```lua
-require("cmp").setup {
-    ...
-    sources = {
-        { name = "path" },
-        { name = "buffer" },
-        { name = "nvim_lsp" },
-        ...
-        { name = "crates" },
-    },
-}
-```
+### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
 
-<details>
-<summary>Or add it lazily.</summary>
-
-```lua
-vim.api.nvim_create_autocmd("BufRead", {
-    group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
-    pattern = "Cargo.toml",
-    callback = function()
-        cmp.setup.buffer({ sources = { { name = "crates" } } })
-    end,
-})
-```
-</details>
-
-<details>
-<summary>Custom nvim-cmp completion kinds</summary>
-
-Enable custom completion kind in the config.
+Custom completion kinds are enabled by default, but icons need to be specified
+manually. The default kind names and highlight groups are as follows:
 ```lua
 require("crates").setup {
     ...
@@ -125,11 +98,12 @@ require("crates").setup {
 This will set a custom completion `cmp.kind_text` and `cmp.kind_hl_group` attributes
 to completion items for `nvim-cmp`.
 
-Depending on how you've set up [the nvim-cmp menu](https://github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance#basic-customisations)
-you'll have to handle these explicitly.
-If you haven't changed `nvim-cmp`s `formatting` configuration everything should work out of the box.
+<details>
+<summary>Custom nvim-cmp kind icons</summary>
 
-Here's an example of how add custom icons.
+How custom icons can be added depends on how you've set up [the nvim-cmp menu](https://github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance#basic-customisations).
+
+Here's an example of how add custom icons, you might need to adapt some things.
 ```lua
 local kind_icons = {
     ["Class"] = "🅒 ",
@@ -175,57 +149,15 @@ require("cmp").setup({
 ```
 </details>
 
-### [coq.nvim](https://github.com/ms-jpq/coq_nvim) source
-Enable it in the setup, and optionally change the display name.
-```lua
-require("crates").setup {
-    ...
-    completion = {
-        ...
-        coq = {
-            enabled = true,
-            name = "crates.nvim",
-        },
-    },
-}
-```
-
-### Crate name completion
-
-Crate names in dependencies can be completed from searches on `crates.io`. This has to be
-enabled seperately:
-
-```lua
-require("crates").setup {
-    ...
-    completion = {
-        crates = {
-            enabled = true -- disabled by default
-            max_results = 8 -- The maximum number of search results to display
-            min_chars = 3 -- The minimum number of charaters to type before completions begin appearing
-        }
-    }
-}
-```
-
 ## Code actions
-Code actions are supported in a few different ways, either by the [in-process language server](#in-process-language-server),
-which also supports completion, or by the null-ls/none-ls source.
+Code actions work through the [in-process language server](#in-process-language-server).
+But you can also set up key mappings for specific actions. See [key mappings](#key-mappings).
 
-### [null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim)/[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim) source
-Enable it in the setup, and optionally change the display name.
-```lua
-require("crates").setup {
-    ...
-    null_ls = {
-        enabled = true,
-        name = "crates.nvim",
-    },
-}
-```
+## Hover
+Hover is supported through the [in-process language server](#in-process-language-server).
+But you can also set up key mappings for specific menus. See [key mappings](#key-mappings).
 
 # Config
-
 For more information about the config types have a look at the vimdoc or [`lua/crates/config/types.lua`](https://github.com/Saecki/crates.nvim/blob/main/lua/crates/config/types.lua).
 
 ## Default

--- a/docgen/wiki/Documentation-unstable.md
+++ b/docgen/wiki/Documentation-unstable.md
@@ -1,13 +1,10 @@
 Documentation for `crates.nvim` `unstable`
 
 # Features
-- Complete crate names, versions and features using one of:
-    - In-process language server (`lsp`)
-    - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source (`completion.cmp`)
-    - [coq.nvim](https://github.com/ms-jpq/coq_nvim) source (`completion.coq`)
-- Code actions using one of:
-    - In-process language server (`lsp`)
-    - [null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim)/[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim)
+- In-process language server (`lsp`)
+    - Complete crate names, versions and features
+    - Code actions
+    - Hover
 - Update crates to newest compatible version
 - Upgrade crates to newest version
 - Respect existing version requirements and update them in an elegant way (`smart_insert`)
@@ -31,10 +28,12 @@ Documentation for `crates.nvim` `unstable`
 # Setup
 
 ## In-process language server
-This is the recommended way to enable completion and code actions.
+The in-process langauge server is disabled by default. It can be enabled
+to support completions, code actions, and hover.
 
 Enable the in-process language server in the setup and select whether to enable
-code actions, auto completion and hover.
+code actions, auto completion and hover. The `on_attach` function, or the `LspAttach`
+autocmd can be used to setup key mappings, just like for other language servers.
 ```lua
 require("crates").setup {
     ...
@@ -52,56 +51,30 @@ require("crates").setup {
 ```
 
 ## Auto completion
-Completion is supported in a few different ways, either by the [in-process language server](#in-process-language-server),
-which also supports code actions, or by one of the following sources.
+Auto completion works through the [in-process language server](#in-process-language-server).
 
-### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
+### Crate name completion
 
-Enable it in the setup.
+Crate names of dependencies can be completed from searches on `crates.io`.
+This has to be enabled seperately:
+
 ```lua
 require("crates").setup {
     ...
     completion = {
-        ...
-        cmp = {
-            enabled = true,
-        },
-    },
+        crates = {
+            enabled = true -- Disabled by default
+            max_results = 8 -- The maximum number of search results to display
+            min_chars = 3 -- The minimum number of charaters to type before completions begin appearing
+        }
+    }
 }
 ```
 
-And add it to your list of sources.
-```lua
-require("cmp").setup {
-    ...
-    sources = {
-        { name = "path" },
-        { name = "buffer" },
-        { name = "nvim_lsp" },
-        ...
-        { name = "crates" },
-    },
-}
-```
+### [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) source
 
-<details>
-<summary>Or add it lazily.</summary>
-
-```lua
-vim.api.nvim_create_autocmd("BufRead", {
-    group = vim.api.nvim_create_augroup("CmpSourceCargo", { clear = true }),
-    pattern = "Cargo.toml",
-    callback = function()
-        cmp.setup.buffer({ sources = { { name = "crates" } } })
-    end,
-})
-```
-</details>
-
-<details>
-<summary>Custom nvim-cmp completion kinds</summary>
-
-Enable custom completion kind in the config.
+Custom completion kinds are enabled by default, but icons need to be specified
+manually. The default kind names and highlight groups are as follows:
 ```lua
 require("crates").setup {
     ...
@@ -125,11 +98,12 @@ require("crates").setup {
 This will set a custom completion `cmp.kind_text` and `cmp.kind_hl_group` attributes
 to completion items for `nvim-cmp`.
 
-Depending on how you've set up [the nvim-cmp menu](https://github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance#basic-customisations)
-you'll have to handle these explicitly.
-If you haven't changed `nvim-cmp`s `formatting` configuration everything should work out of the box.
+<details>
+<summary>Custom nvim-cmp kind icons</summary>
 
-Here's an example of how add custom icons.
+How custom icons can be added depends on how you've set up [the nvim-cmp menu](https://github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance#basic-customisations).
+
+Here's an example of how add custom icons, you might need to adapt some things.
 ```lua
 local kind_icons = {
     ["Class"] = "🅒 ",
@@ -175,57 +149,15 @@ require("cmp").setup({
 ```
 </details>
 
-### [coq.nvim](https://github.com/ms-jpq/coq_nvim) source
-Enable it in the setup, and optionally change the display name.
-```lua
-require("crates").setup {
-    ...
-    completion = {
-        ...
-        coq = {
-            enabled = true,
-            name = "crates.nvim",
-        },
-    },
-}
-```
-
-### Crate name completion
-
-Crate names in dependencies can be completed from searches on `crates.io`. This has to be
-enabled seperately:
-
-```lua
-require("crates").setup {
-    ...
-    completion = {
-        crates = {
-            enabled = true -- disabled by default
-            max_results = 8 -- The maximum number of search results to display
-            min_chars = 3 -- The minimum number of charaters to type before completions begin appearing
-        }
-    }
-}
-```
-
 ## Code actions
-Code actions are supported in a few different ways, either by the [in-process language server](#in-process-language-server),
-which also supports completion, or by the null-ls/none-ls source.
+Code actions work through the [in-process language server](#in-process-language-server).
+But you can also set up key mappings for specific actions. See [key mappings](#key-mappings).
 
-### [null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim)/[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim) source
-Enable it in the setup, and optionally change the display name.
-```lua
-require("crates").setup {
-    ...
-    null_ls = {
-        enabled = true,
-        name = "crates.nvim",
-    },
-}
-```
+## Hover
+Hover is supported through the [in-process language server](#in-process-language-server).
+But you can also set up key mappings for specific menus. See [key mappings](#key-mappings).
 
 # Config
-
 For more information about the config types have a look at the vimdoc or [`lua/crates/config/types.lua`](https://github.com/Saecki/crates.nvim/blob/main/lua/crates/config/types.lua).
 
 ## Default

--- a/lua/crates/config/init.lua
+++ b/lua/crates/config/init.lua
@@ -335,15 +335,6 @@ entry(schema_text, {
         Format string used when there was an error loading crate information.
     ]],
 })
--- DEPRECATED
-entry(M.schema, {
-    name = "open_programs",
-    type = STRING_ARRAY_TYPE,
-    deprecated = {
-        msg = "`vim.ui.open()` is used instead",
-        hard = true,
-    },
-})
 
 
 local schema_hl = section_entry(M.schema, {
@@ -1418,6 +1409,9 @@ entry(schema_completion_cmp, {
             require("crates.completion.cmp").setup()
         <
     ]],
+    deprecated = {
+        msg = "the nvim-cmp source will be removed soon. Use the in-process language server instead.",
+    },
 })
 entry(schema_completion_cmp, {
     name = "use_custom_kind",
@@ -1502,6 +1496,9 @@ entry(schema_completion_coq, {
     description = [[
         Whether to load and register the |coq_nvim| source.
     ]],
+    deprecated = {
+        msg = "the coq_nvim source will be removed soon. Use the in-process language server instead.",
+    },
 })
 entry(schema_completion_coq, {
     name = "name",
@@ -1653,12 +1650,13 @@ entry(schema_completion_crates, {
         complete a crate name.
     ]],
 })
--- deprecated
+-- DEPRECATED
 entry(M.schema, {
     name = "src",
     type = BOOLEAN_TYPE,
     deprecated = {
         new_field = { "completion" },
+        hard = true,
     }
 })
 
@@ -1673,6 +1671,9 @@ local schema_null_ls = section_entry(M.schema, {
         Configuration options for null-ls.nvim actions.
     ]],
     fields = {},
+    deprecated = {
+        msg = "the null-ls source will be removed soon. Use the in-process language server instead.",
+    },
 })
 entry(schema_null_ls, {
     name = "enabled",
@@ -1757,6 +1758,8 @@ entry(schema_lsp, {
     default_text = "function(client, bufnr) end",
     description = [[
         Callback to run when the in-process language server attaches to a buffer.
+
+        NOTE: Alternatively you can also use the `LspAttach` autocmd.
 
         NOTE: Ignored if |crates-config-autoload| is disabled.
     ]],

--- a/lua/crates/health.lua
+++ b/lua/crates/health.lua
@@ -33,8 +33,6 @@ function M.check()
         vim.health.ok("null-ls.nvim installed")
     elseif state.cfg.null_ls.enabled then
         vim.health.warn("null-ls.nvim not found, but `null_ls.enabled` is set")
-    else
-        vim.health.info("null-ls.nvim not found")
     end
     if state.cfg.lsp.enabled and state.cfg.lsp.actions and state.cfg.null_ls.enabled then
         vim.health.warn("lsp actions and null-ls.nvim actions are enabled, only one should be necessary")
@@ -44,24 +42,18 @@ function M.check()
         vim.health.ok("neoconf.nvim installed")
     elseif state.cfg.neoconf.enabled then
         vim.health.warn("neoconf.nvim not found, but `neoconf.enabled` is set")
-    else
-        vim.health.info("neoconf.nvim not found")
     end
 
     if lualib_installed("cmp") then
         vim.health.ok("nvim-cmp installed")
     elseif state.cfg.completion.cmp.enabled then
         vim.health.warn("nvim-cmp not found, but `completion.cmp.enabled` is set")
-    else
-        vim.health.info("nvim-cmp not found")
     end
 
     if lualib_installed("coq") then
         vim.health.ok("coq_nvim installed")
     elseif state.cfg.completion.coq.enabled then
         vim.health.warn("coq_nvim not found, but `completion.coq.enabled` is set")
-    else
-        vim.health.info("coq_nvim not found")
     end
 
     if state.cfg.lsp.enabled and state.cfg.lsp.completion then

--- a/scripts/gen_types.lua
+++ b/scripts/gen_types.lua
@@ -16,7 +16,8 @@ local function gen_config_types(lines, schema, type_name, user)
     ---@param s SchemaElement
     ---@return boolean
     local function skip(s)
-        return s.deprecated ~= nil or s.hidden and user
+        return s.deprecated ~= nil and (s.deprecated.hard or s.deprecated.new_field)
+            or s.hidden and user
     end
 
     for _, s in ipairs(schema) do


### PR DESCRIPTION
This deprecates the completion engine specific sources, and the null-ls actions.
The in-process language server can be used instead.