### PR TITLE
fix: handle winborder correctly if the global option is not set

### DIFF
--- a/lua/crates/popup/common.lua
+++ b/lua/crates/popup/common.lua
@@ -178,9 +178,17 @@ local function popup_border()
         ---@type string[]
         local winborder = vim.opt_global.winborder:get()
 
-        -- This returns { "<value>" } if something like "single" or "rounded"
-        -- is set, or a list of border chars.
-        return #winborder == 1 and winborder[1] or winborder
+        -- This returns:
+        -- * An empty list if unset, or
+        -- * { "<value>" } if something like "single" or "rounded" is set, or
+        -- * A list of border chars.
+        if #winborder == 0 then
+            return "none"
+        elseif #winborder == 1 then
+            return winborder[1]
+        else
+            return winborder
+        end
     else
         return "none"
     end


### PR DESCRIPTION
<!-- Please use conventional commit messages for PR titles: https://www.conventionalcommits.org/en/v1.0.0 -->

Problem: I believe `vim.opt_global.winborder:get()` will return an empty list if user hasn't set `winborder`. Thus, Neovim will complain "invalid number of border chars" if neither the global option `winborder` nor the plugins' option `popup.border` is configured.