### PR TITLE
feat!: lazy auto setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,6 @@ lua require('crates').setup()
 </details>
 
 
-<details>
-<summary>For lazy loading.</summary>
-
-```lua
-{
-    'saecki/crates.nvim',
-    event = { "BufRead Cargo.toml" },
-    config = function()
-        require('crates').setup()
-    end,
-}
-```
-</details>
-
 ## [Documentation](https://github.com/Saecki/crates.nvim/wiki)
 - [Stable](https://github.com/Saecki/crates.nvim/wiki/Documentation-v0.7.1)
 - [Unstable](https://github.com/Saecki/crates.nvim/wiki/Documentation-unstable)

--- a/lua/crates/command.lua
+++ b/lua/crates/command.lua
@@ -1,41 +1,37 @@
-local actions = require("crates.actions")
-local core = require("crates.core")
-local popup = require("crates.popup")
-
 local M = {}
 
 ---@type {[1]: string, [2]: function}[]
 local sub_commands = {
-    { "hide",                               core.hide },
-    { "show",                               core.show },
-    { "toggle",                             core.toggle },
-    { "update",                             core.update },
-    { "reload",                             core.reload },
+    { "hide",                               function() return require("crates.core").hide() end },
+    { "show",                               function() return require("crates.core").show() end },
+    { "toggle",                             function() return require("crates.core").toggle() end },
+    { "update",                             function() return require("crates.core").update() end },
+    { "reload",                             function() return require("crates.core").reload() end },
 
-    { "upgrade_crate",                      actions.upgrade_crate },
-    { "upgrade_crates",                     actions.upgrade_crates },
-    { "upgrade_all_crates",                 actions.upgrade_all_crates },
-    { "update_crate",                       actions.update_crate },
-    { "update_crates",                      actions.update_crates },
-    { "update_all_crates",                  actions.update_all_crates },
-    { "use_git_source",                     actions.use_git_source },
+    { "upgrade_crate",                      function() return require("crates.actions").upgrade_crate() end },
+    { "upgrade_crates",                     function() return require("crates.actions").upgrade_crates() end },
+    { "upgrade_all_crates",                 function() return require("crates.actions").upgrade_all_crates() end },
+    { "update_crate",                       function() return require("crates.actions").update_crate() end },
+    { "update_crates",                      function() return require("crates.actions").update_crates() end },
+    { "update_all_crates",                  function() return require("crates.actions").update_all_crates() end },
+    { "use_git_source",                     function() return require("crates.actions").use_git_source() end },
 
-    { "expand_plain_crate_to_inline_table", actions.expand_plain_crate_to_inline_table },
-    { "extract_crate_into_table",           actions.extract_crate_into_table },
+    { "expand_plain_crate_to_inline_table", function() return require("crates.actions").expand_plain_crate_to_inline_table() end },
+    { "extract_crate_into_table",           function() return require("crates.actions").extract_crate_into_table() end },
 
-    { "open_homepage",                      actions.open_homepage },
-    { "open_repository",                    actions.open_repository },
-    { "open_documentation",                 actions.open_documentation },
-    { "open_cratesio",                      actions.open_crates_io },
+    { "open_homepage",                      function() return require("crates.actions").open_homepage() end },
+    { "open_repository",                    function() return require("crates.actions").open_repository() end },
+    { "open_documentation",                 function() return require("crates.actions").open_documentation() end },
+    { "open_cratesio",                      function() return require("crates.actions").open_crates_io() end },
 
-    { "popup_available",                    popup.available },
-    { "show_popup",                         popup.show },
-    { "show_crate_popup",                   popup.show_crate },
-    { "show_versions_popup",                popup.show_versions },
-    { "show_features_popup",                popup.show_features },
-    { "show_dependencies_popup",            popup.show_dependencies },
-    { "focus_popup",                        popup.focus },
-    { "hide_popup",                         popup.hide },
+    { "popup_available",                    function() return require("crates.popup").available() end },
+    { "show_popup",                         function() return require("crates.popup").show() end },
+    { "show_crate_popup",                   function() return require("crates.popup").show_crate() end },
+    { "show_versions_popup",                function() return require("crates.popup").show_versions() end },
+    { "show_features_popup",                function() return require("crates.popup").show_features() end },
+    { "show_dependencies_popup",            function() return require("crates.popup").show_dependencies() end },
+    { "focus_popup",                        function() return require("crates.popup").focus() end },
+    { "hide_popup",                         function() return require("crates.popup").hide() end },
 }
 
 ---@param arglead string

--- a/lua/crates/config/init.lua
+++ b/lua/crates/config/init.lua
@@ -1993,34 +1993,25 @@ local function setup_neoconf(config)
 end
 
 ---@param schema table<string,SchemaElement>|SchemaElement[]
----@param user_config table<string,any>
 ---@return table
-local function build_config(schema, user_config)
+local function build_config(schema)
     ---@type table<string,any>
     local config = {}
 
     for _, elem in ipairs(schema) do
         local key = elem.name
-        local user_value = user_config[key]
-        local value_type = type(user_value)
 
         if elem.type.config_type == "section" then
-            if value_type == "table" then
-                config[key] = build_config(elem.fields, user_value)
-            else
-                config[key] = build_config(elem.fields, {})
-            end
+            config[key] = build_config(elem.fields)
         else
-            if matches_type(value_type, elem.type) then
-                config[key] = user_value
-            else
-                config[key] = elem.default
-            end
+            config[key] = elem.default
         end
     end
 
     return config
 end
+
+local current_config = build_config(M.schema)
 
 ---comment
 ---@param user_config table<string,any>?
@@ -2035,11 +2026,11 @@ function M.build(user_config)
 
     handle_deprecated({}, M.schema, user_config, user_config)
     validate_schema({}, M.schema, user_config)
-    local config = build_config(M.schema, user_config)
-    if config.neoconf.enabled then
-        return setup_neoconf(config)
+    current_config = vim.tbl_deep_extend("force", current_config, user_config)
+    if current_config.neoconf.enabled then
+        return setup_neoconf(current_config)
     else
-        return config
+        return current_config
     end
 end
 

--- a/lua/crates/init.lua
+++ b/lua/crates/init.lua
@@ -1,12 +1,8 @@
 local actions = require("crates.actions")
 local async = require("crates.async")
-local command = require("crates.command")
-local config = require("crates.config")
 local core = require("crates.core")
-local highlight = require("crates.highlight")
 local popup = require("crates.popup")
 local state = require("crates.state")
-local util = require("crates.util")
 
 local function attach()
     if state.cfg.completion.cmp.enabled then
@@ -18,15 +14,12 @@ local function attach()
     end
 
     core.update()
-    state.cfg.on_attach(util.current_buf())
+    state.cfg.on_attach(require("crates.util").current_buf())
 end
 
 ---@param cfg crates.UserConfig
 local function setup(cfg)
-    state.cfg = config.build(cfg)
-
-    command.register()
-    highlight.define()
+    state.cfg = require("crates.config").build(cfg)
 
     ---@type integer
     local group = vim.api.nvim_create_augroup("Crates", {})

--- a/plugin/crates.lua
+++ b/plugin/crates.lua
@@ -1,0 +1,10 @@
+require("crates.command").register()
+require("crates.highlight").define()
+
+vim.api.nvim_create_autocmd("BufRead", {
+    pattern = "Cargo.toml",
+    once = true,
+    callback = function()
+        require("crates").setup({})
+    end,
+})


### PR DESCRIPTION
Problem:

The user is required to call setup() even if they are perfectly happy with the default options. Also, requiring every user to lazy load is annoying, and also requires that the plugin manager the user is using is supporting this out of the box

Solution:

Make setup optional, and lazy load the plugin automatically

Context:
Neovim has recently added some documentation of developing a lua plugin with some "best practices" https://github.com/neovim/neovim/blob/master/runtime/doc/lua-plugin.txt

In the Initialization section, it is recommended to allow users to opt out of calling setup if the default options are working perfectly fine. For me they are working perfectly fine, and I agree that calling setup is unnecessary in this case.

They also have a section talking about lazy loading, and making a case for this to be handled by the plugin instead of the user themselves. I agree with this, and saw a good potential to automatically do it here😄

