### PR TITLE
fix: use correct name for search callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - deprecate the nvim-cmp, coq_nvim, and null-ls sources (#172)
 
 ### Bug Fixes
+- crate name completion errors (#179)
 - missing crates in completion (#170)
 - prevent lsp request from beeing endlesly pending (#167)
 - handle winborder:get return correctly (#165)

--- a/lua/crates/api.lua
+++ b/lua/crates/api.lua
@@ -657,7 +657,7 @@ function M.run_queued_jobs()
     -- Prioritise crate searches
     if #M.search_queue > 0 then
         local job = table.remove(M.search_queue, 1)
-        fetch_search(job.name, job.search_callbacks)
+        fetch_search(job.name, job.callbacks)
         return
     end
 


### PR DESCRIPTION
`run_queued_jobs` was referring to a non-existent `QueuedSearchJob` field:

```sh
$ rg search_callbacks ./lua
lua/crates/api.lua
660:        fetch_search(job.name, job.search_callbacks)
```

This fed `nil` into `fetch_search`, causing the following error:

```sh
vim.schedule callback: .../.local/share/nvim/lazy/crates.nvim/lua/crates/api.lua:236: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
	[C]: in function 'ipairs'
	.../.local/share/nvim/lazy/crates.nvim/lua/crates/api.lua:236: in function 'on_exit'
	.../.local/share/nvim/lazy/crates.nvim/lua/crates/api.lua:111: in function <.../.local/share/nvim/lazy/crates.nvim/lua/crates/api.lua:109>
```