### PR TITLE
ci: do not specify checkout ref

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,8 +14,6 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v7
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Install neovim
       uses: rhysd/action-setup-vim@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
       run: make types
 
     - name: Commit changes
+      if: github.event_name == 'push'
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
         file_pattern: lua/crates/config/types.lua
@@ -35,6 +36,7 @@ jobs:
       run: make doc
 
     - name: Commit changes
+      if: github.event_name == 'push'
       uses: stefanzweifel/git-auto-commit-action@v7
       with:
         file_pattern: README.md doc/crates.txt docgen/wiki


### PR DESCRIPTION
Removes the `head_ref` checkout reference in the CI build job, allowing pull request workflow runs to use their default reference which is a temporary merge commit. This fixes CI runs on pull requests that originate from forks, because `head_ref` expands to the PR source branch, which likely does not exist in the base repository (or worse, a branch with the same name exists but contains unrelated changes).

Restrict auto-commits to `push` events only. This prevents pull requests from triggering auto-commit steps that fail when attempting to switch to a PR source branch [1] that exists only on a fork. Generated type/doc changes will continue to get auto-committed on pushes to this repository's branches (including `main`). Pull requests will continue to generate types/docs and run tests.

Closes: https://github.com/saecki/crates.nvim/issues/66

[1] https://github.com/stefanzweifel/git-auto-commit-action/blob/92648143fd6aebb695590bfe3fc28f92bcf383e4/entrypoint.sh#L73